### PR TITLE
Make code coverage accessible in Chrome devtools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ a simple, tap-compliant test runner for the browser
 - is interoperable with TAP Version 13
 - nested sub-tests run in an iframe
 - has a recognizable testing interface
+- can be used for automated testing
+- can be used to assert coverage goals
 
 ## Interface
 
@@ -23,11 +25,14 @@ The following are exposed in the testing interface:
 - `todo`: An `it` whose callback _is_ run and is expected to fail.
 - `waitFor`: Ensures the test does not exit until given promise settles.
 - `assert`: Simple assertion call that expects a boolean.
+- `cover`: Sets a coverage goal for the given url.
 
 ### Events
 
 - `x-test-ping`: root responds ('x-test-pong', { status: 'started'|'ended' })
 - `x-test-ended`: all tests have completed or we bailed out
+- `x-test-cover-start`: root responds ('x-test-cover-ended')
+- `x-test-cover`: [internal] signal to test for coverage on a particular file
 - `x-test-bail`: [internal] signal to quit test early
 - `x-test-queue`: [internal] queues a new test
 - `x-test-next`: [internal] destroy current test and create a new one
@@ -39,6 +44,11 @@ The following are exposed in the testing interface:
 The following parameters can be passed in via a url `search`:
 
 - `x-test-no-reporter`: turns off custom reporting tool ui
+- `x-test-cover`: turns on coverage reporting**
+
+**See `test.js` for an example of how to capture coverage information in
+puppeteer and send it to your test to allow your automated test to fail due to
+unmet coverage goals.
 
 ## Execution
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <meta charset="UTF-8">
+    <script type="module" src="index.js"></script>
+    <h3>test (all)</h3>
+  </body>
+</html>

--- a/demo/index.js
+++ b/demo/index.js
@@ -28,5 +28,3 @@ todo('foo', 'demonstrate passing "todo"', () => {
 test('./test-basic.html');
 test('./test-sibling.html');
 test('./nested/');
-test('./test-coverage.html');
-test('./test-tap.html');

--- a/demo/nested/index.html
+++ b/demo/nested/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <meta charset="UTF-8">
+    <script type="module" src="index.js"></script>
+    <h3>nested</h3>
+  </body>
+</html>

--- a/demo/nested/index.js
+++ b/demo/nested/index.js
@@ -1,0 +1,3 @@
+import { test } from '../../x-test.js';
+
+test('./nested/index.html');

--- a/demo/nested/nested/index.html
+++ b/demo/nested/nested/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <meta charset="UTF-8">
+    <script type="module" src="index.js"></script>
+    <h3>nested (nested)</h3>
+  </body>
+</html>

--- a/demo/nested/nested/index.js
+++ b/demo/nested/nested/index.js
@@ -1,0 +1,6 @@
+import { assert, it } from '../../../x-test.js';
+
+it('nested tests should be found', async () => {
+  await false;
+  assert(true);
+});

--- a/demo/test-basic.html
+++ b/demo/test-basic.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <meta charset="UTF-8">
+    <script type="module" src="test-basic.js"></script>
+    <h3>test-basic</h3>
+  </body>
+</html>

--- a/demo/test-basic.js
+++ b/demo/test-basic.js
@@ -1,0 +1,20 @@
+import { it, skip, test, waitFor } from '../x-test.js';
+
+skip('takes too long', 'loooong test', async () => {
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  throw new Error(`i'm broken.`);
+});
+
+it('medium test', async () => {
+  await new Promise(resolve => setTimeout(resolve, 500));
+});
+
+(async () => {
+  // Call some api to get a list of things which should each define an "it"...
+  const promise = new Promise(resolve => setTimeout(resolve, 1000));
+  waitFor(promise);
+  await promise;
+  it('dynamically defined test based on awaited information', () => {});
+})();
+
+test('./test-chained.html');

--- a/demo/test-chained.html
+++ b/demo/test-chained.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <meta charset="UTF-8">
+    <script type="module" src="test-chained.js"></script>
+    <h3>test-chained</h3>
+  </body>
+</html>

--- a/demo/test-chained.js
+++ b/demo/test-chained.js
@@ -1,0 +1,9 @@
+import { assert, it, skip } from '../x-test.js';
+
+it('objects pass assertion checks', () => {
+  assert({});
+});
+
+skip('false is still not true', 'do the impossible', () => {
+  assert(false);
+});

--- a/demo/test-sibling.html
+++ b/demo/test-sibling.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <meta charset="UTF-8">
+    <script type="module" src="test-sibling.js"></script>
+    <h3>test-sibling</h3>
+  </body>
+</html>

--- a/demo/test-sibling.js
+++ b/demo/test-sibling.js
@@ -1,0 +1,15 @@
+import { assert, it, todo } from '../x-test.js';
+
+it('dom test', () => {
+  const div = document.createElement('div');
+  div.style.width = '100px';
+  div.style.height = '100px';
+  div.style.backgroundColor = 'deeppink';
+  div.id = 'dom-test';
+  document.body.appendChild(div);
+  assert(document.getElementById('dom-test'));
+});
+
+todo('make false true', 'do the impossible', () => {
+  assert(false);
+});

--- a/index.css
+++ b/index.css
@@ -1,0 +1,12 @@
+:root {
+  font-family: sans-serif;
+  font-size: 1.2rem;
+}
+
+a:any-link {
+  color: #0074D9;
+}
+
+a:not(:hover) {
+  text-decoration: none;
+}

--- a/index.html
+++ b/index.html
@@ -1,8 +1,21 @@
 <!doctype html>
 <html>
-  <body>
+  <head>
     <meta charset="UTF-8">
+    <title>x-test</title>
+    <link rel="stylesheet" href="index.css">
     <script type="module" src="index.js"></script>
-    <h3>View Console</h3>
+  </head>
+  <body>
+    <h1>x-test</h1>
+    <p>a simple, tap-compliant test runner for the browser</p>
+    <ul>
+      <li>
+        <a href="demo">Demo</a>
+      </li>
+      <li>
+        <a href="test">Test</a>
+      </li>
+    </ul>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
-import { test } from './x-test.js';
+import { it, assert } from './x-test.js';
 
-test('./test/index.html');
+it('start testing!', () => {
+  assert(true);
+});

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
   "files": [
     "LICENSE",
     "/index.html",
+    "/index.css",
     "/index.js",
     "/test.js",
     "/x-test.js",
-    "/test"
+    "/demo/**",
+    "/test/**"
   ],
   "devDependencies": {
     "@netflix/element-server": "^1.0.12",

--- a/test.js
+++ b/test.js
@@ -3,26 +3,26 @@ const puppeteer = require('puppeteer');
 
 (async () => {
   try {
+    // Open our browser.
     const browser = await puppeteer.launch({ timeout: 10000 });
     const page = await browser.newPage();
 
+    // Starts to gather coverage information for JS and CSS files
+    await page.coverage.startJSCoverage();
+
     // Before navigation, start mapping browser logs to stdout.
-    // eslint-disable-next-line no-console
-    page.on('console', message => console.log(message.text()));
+    page.on('console', message => console.log(message.text())); // eslint-disable-line no-console
 
     // Visit our test page.
-    await page.goto('http://0.0.0.0:8080/node_modules/@netflix/x-test/?x-test-no-reporter');
+    await page.goto('http://0.0.0.0:8080/node_modules/@netflix/x-test/test/?x-test-cover');
 
     // Wait to be signaled about the end of the test. Because the test may have
     // not started, already started, or already ended, ping for status.
     await page.evaluate(async () => {
-      return new Promise(resolve => {
+      await new Promise(resolve => {
         const onMessage = evt => {
           const { type, data } = evt.data;
-          if (
-            type === 'x-test-ended' ||
-            (type === 'x-test-pong' && data.ended)
-          ) {
+          if (type === 'x-test-ended' || (type === 'x-test-pong' && data.ended)) {
             top.removeEventListener('message', onMessage);
             resolve();
           }
@@ -32,11 +32,29 @@ const puppeteer = require('puppeteer');
       });
     });
 
+    // Gather coverage information.
+    const js = await page.coverage.stopJSCoverage();
+
+    // Send coverage information to x-test and await test completion.
+    await page.evaluate(async data => {
+      await new Promise(resolve => {
+        const onMessage = evt => {
+          const { type } = evt.data;
+          if (type === 'x-test-cover-ended') {
+            top.removeEventListener('message', onMessage);
+            resolve();
+          }
+        };
+        top.addEventListener('message', onMessage);
+        top.postMessage({ type: 'x-test-cover-start', data }, '*');
+      });
+    }, { js });
+
+    // Close our browser.
     await browser.close();
   } catch (err) {
     // Ensure we exit with a non-zero code if anything fails (e.g., timeout).
-    // eslint-disable-next-line no-console
-    console.error(err);
+    console.error(err); // eslint-disable-line no-console
     process.exit(1);
   }
 })();

--- a/test/test-coverage.html
+++ b/test/test-coverage.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <meta charset="UTF-8">
+    <script type="module" src="test-coverage.js"></script>
+    <h3>test-basic</h3>
+  </body>
+</html>

--- a/test/test-coverage.js
+++ b/test/test-coverage.js
@@ -1,0 +1,53 @@
+import { it, assert, __RootTest__ } from '../x-test.js';
+
+const url = new URL('/fake.js', import.meta.url).href;
+const text = `// Fake file to test coverage on.
+class MyFakeClass {
+  fakeFunction(fake) {
+    if (fake) {
+      /*
+       *
+       *
+       *
+       *
+       *
+       */
+    } else {
+      /*
+       *
+       *
+       *
+       *
+       *
+       */
+    }
+  }
+}
+
+export default MyFakeClass;
+`;
+
+const js = [
+  {
+    url,
+    text,
+    ranges: [{ start: 0, end: 162 }, { start: 239, end: 275 }],
+  },
+];
+
+const expectedOutput = `1       |  // Fake file to test coverage on.
+…
+12      |      } else {
+13 !    |        /*
+…
+19 !    |         */
+20 !    |      }
+…
+25      |  `;
+
+it('test coverage', () => {
+  const analysis = __RootTest__.analyzeUrlCoverage(js, url, 95);
+  assert(analysis.ok === false);
+  assert(analysis.output === expectedOutput);
+  assert(analysis.percent === 72);
+});

--- a/test/test-tap.html
+++ b/test/test-tap.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <meta charset="UTF-8">
+    <script type="module" src="test-tap.js"></script>
+    <h3>test-basic</h3>
+  </body>
+</html>

--- a/test/test-tap.js
+++ b/test/test-tap.js
@@ -1,0 +1,35 @@
+import { it, assert, __Tap__ } from '../x-test.js';
+
+it('version line is correct', () => {
+  assert(__Tap__.version() === 'TAP Version 13');
+});
+
+it('diagnostic works', () => {
+  assert(__Tap__.diagnostic('my message') === '# my message');
+});
+
+it('testLine works', () => {
+  assert(__Tap__.testLine(true, 1, 'first test') === 'ok - 1 first test');
+  assert(__Tap__.testLine(false, 1, 'first test') === 'not ok - 1 first test');
+  assert(__Tap__.testLine(false, 1, 'first test', 'todo', 'because') === 'not ok - 1 first test # todo because');
+});
+
+it('yaml works', () => {
+  const expected = `  ---
+  message: my message
+  severity: error
+  stack: |-
+    one
+    two
+    three
+  ...`;
+  assert(__Tap__.yaml('my message', 'error', { stack: 'one\ntwo\nthree'}) === expected);
+});
+
+it('bailOut works', () => {
+  assert(__Tap__.bailOut('oh no!') === 'Bail out! oh no!');
+});
+
+it('plan works', () => {
+  assert(__Tap__.plan(999) === '1..999');
+});


### PR DESCRIPTION
This PR allows you to add coverage tests on a per-file basis. Note that you cannot simply access the coverage information from inside your test code — you have to send it in via `puppeteer`.

I was able to keep most of the logic inside of `x-test`, but there's some necessary spillover into the bespoke testing code `test.js`. I think this is OK for now though as that file is small and easy to copy around. Also, I didn't change it in a backwards-incompatible way.