### PR TITLE
Simplify x-test.

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -10,10 +10,7 @@ it('truthy things pass assertion tests', async () => {
   assert(1);
 });
 
-todo(
-  `is
-handled...`,
-  `multi
+todo(`multi
 line
 test`,
   () => {
@@ -21,7 +18,7 @@ test`,
   }
 );
 
-todo('foo', 'demonstrate passing "todo"', () => {
+todo('demonstrate passing "todo"', () => {
   assert(1);
 });
 

--- a/demo/test-basic.js
+++ b/demo/test-basic.js
@@ -1,6 +1,6 @@
 import { it, skip, test, waitFor } from '../x-test.js';
 
-skip('takes too long', 'loooong test', async () => {
+skip('loooong test', async () => {
   await new Promise(resolve => setTimeout(resolve, 1000));
   throw new Error(`i'm broken.`);
 });

--- a/demo/test-chained.js
+++ b/demo/test-chained.js
@@ -4,6 +4,6 @@ it('objects pass assertion checks', () => {
   assert({});
 });
 
-skip('false is still not true', 'do the impossible', () => {
+skip('do the impossible', () => {
   assert(false);
 });

--- a/demo/test-sibling.js
+++ b/demo/test-sibling.js
@@ -10,6 +10,6 @@ it('dom test', () => {
   assert(document.getElementById('dom-test'));
 });
 
-todo('make false true', 'do the impossible', () => {
+todo('do the impossible', () => {
   assert(false);
 });

--- a/index.css
+++ b/index.css
@@ -1,6 +1,5 @@
 :root {
   font-family: sans-serif;
-  font-size: 1.2rem;
 }
 
 a:any-link {

--- a/test/index.js
+++ b/test/index.js
@@ -11,9 +11,7 @@ it('truthy things pass assertion tests', async () => {
 });
 
 todo(
-  `is
-handled...`,
-  `multi
+`multi
 line
 test`,
   () => {
@@ -21,12 +19,13 @@ test`,
   }
 );
 
-todo('foo', 'demonstrate passing "todo"', () => {
+todo('demonstrate passing "todo"', () => {
   assert(1);
 });
 
 test('./test-basic.html');
 test('./test-sibling.html');
 test('./nested/');
+test('./test-reporter.html');
 test('./test-coverage.html');
 test('./test-tap.html');

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -1,6 +1,6 @@
 import { it, skip, test, waitFor } from '../x-test.js';
 
-skip('takes too long', 'loooong test', async () => {
+skip('loooong test', async () => {
   await new Promise(resolve => setTimeout(resolve, 1000));
   throw new Error(`i'm broken.`);
 });

--- a/test/test-chained.js
+++ b/test/test-chained.js
@@ -4,6 +4,6 @@ it('objects pass assertion checks', () => {
   assert({});
 });
 
-skip('false is still not true', 'do the impossible', () => {
+skip('do the impossible', () => {
   assert(false);
 });

--- a/test/test-reporter.html
+++ b/test/test-reporter.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <meta charset="UTF-8">
+    <script type="module" src="test-reporter.js"></script>
+    <h3>test-basic</h3>
+  </body>
+</html>

--- a/test/test-reporter.js
+++ b/test/test-reporter.js
@@ -1,0 +1,127 @@
+import { it, assert, __XTestReporter__ } from '../x-test.js';
+
+it('parses test', () => {
+  const output = '# http://example.com/test.html';
+  const result = __XTestReporter__.parseOutput(output);
+  assert(result.tag === 'a');
+  assert(Object.keys(result.properties).length === 2);
+  assert(result.properties.href === 'http://example.com/test.html');
+  assert(result.properties.innerText === output);
+  assert(Object.keys(result.attributes).length === 2);
+  assert(result.attributes.output === '');
+  assert(result.attributes.test === '');
+  assert(result.done === false);
+  assert(result.failed === false);
+});
+
+it('parses bail test', () => {
+  const output = 'Bail out! http://example.com/test.html';
+  const result = __XTestReporter__.parseOutput(output);
+  assert(result.tag === 'a');
+  assert(Object.keys(result.properties).length === 2);
+  assert(result.properties.href === 'http://example.com/test.html');
+  assert(result.properties.innerText === output);
+  assert(Object.keys(result.attributes).length === 3);
+  assert(result.attributes.output === '');
+  assert(result.attributes.test === '');
+  assert(result.attributes.bail === '');
+  assert(result.done === false);
+  assert(result.failed === true);
+});
+
+it('parses diagnostic', () => {
+  const output = '# something, anything';
+  const result = __XTestReporter__.parseOutput(output);
+  assert(result.tag === 'div');
+  assert(Object.keys(result.properties).length === 1);
+  assert(result.properties.innerText === output);
+  assert(Object.keys(result.attributes).length === 2);
+  assert(result.attributes.output === '');
+  assert(result.attributes.diagnostic === '');
+  assert(result.done === false);
+  assert(result.failed === false);
+});
+
+it('parses test line', () => {
+  const output = 'ok - 145 this cool thing i tested';
+  const result = __XTestReporter__.parseOutput(output);
+  assert(result.tag === 'div');
+  assert(Object.keys(result.properties).length === 1);
+  assert(result.properties.innerText === output);
+  assert(Object.keys(result.attributes).length === 3);
+  assert(result.attributes.output === '');
+  assert(result.attributes.it === '');
+  assert(result.attributes.ok === '');
+  assert(result.done === false);
+  assert(result.failed === false);
+});
+
+it('parses "SKIP" test line', () => {
+  const output = 'ok - 145 this cool thing i tested # SKIP';
+  const result = __XTestReporter__.parseOutput(output);
+  assert(result.tag === 'div');
+  assert(Object.keys(result.properties).length === 1);
+  assert(result.properties.innerText === output);
+  assert(Object.keys(result.attributes).length === 4);
+  assert(result.attributes.output === '');
+  assert(result.attributes.it === '');
+  assert(result.attributes.ok === '');
+  assert(result.attributes.directive === 'skip');
+  assert(result.done === false);
+  assert(result.failed === false);
+});
+
+it('parses "TODO" test line', () => {
+  const output = 'ok - 145 this cool thing i tested # TODO';
+  const result = __XTestReporter__.parseOutput(output);
+  assert(result.tag === 'div');
+  assert(Object.keys(result.properties).length === 1);
+  assert(result.properties.innerText === output);
+  assert(Object.keys(result.attributes).length === 4);
+  assert(result.attributes.output === '');
+  assert(result.attributes.it === '');
+  assert(result.attributes.ok === '');
+  assert(result.attributes.directive === 'todo');
+  assert(result.done === false);
+  assert(result.failed === false);
+});
+
+it('parses "not ok" test line', () => {
+  const output = 'not ok - 145 this cool thing i tested';
+  const result = __XTestReporter__.parseOutput(output);
+  assert(result.tag === 'div');
+  assert(Object.keys(result.properties).length === 1);
+  assert(result.properties.innerText === output);
+  assert(Object.keys(result.attributes).length === 2);
+  assert(result.attributes.output === '');
+  assert(result.attributes.it === '');
+  assert(result.done === false);
+  assert(result.failed === true);
+});
+
+it('parses "not ok", "TODO" test line', () => {
+  const output = 'not ok - 145 this cool thing i tested # TODO tbd...';
+  const result = __XTestReporter__.parseOutput(output);
+  assert(result.tag === 'div');
+  assert(Object.keys(result.properties).length === 1);
+  assert(result.properties.innerText === output);
+  assert(Object.keys(result.attributes).length === 3);
+  assert(result.attributes.output === '');
+  assert(result.attributes.it === '');
+  assert(result.attributes.directive === 'todo');
+  assert(result.done === false);
+  assert(result.failed === false);
+});
+
+it('parses version', () => {
+  const output = 'TAP version 13';
+  const result = __XTestReporter__.parseOutput(output);
+  assert(result.tag === 'div');
+  assert(Object.keys(result.properties).length === 1);
+  assert(result.properties.innerText === output);
+  assert(Object.keys(result.attributes).length === 2);
+  assert(result.attributes.output === '');
+  assert(result.attributes.version === '');
+  assert(result.done === false);
+  assert(result.failed === false);
+});

--- a/test/test-sibling.js
+++ b/test/test-sibling.js
@@ -10,6 +10,6 @@ it('dom test', () => {
   assert(document.getElementById('dom-test'));
 });
 
-todo('make false true', 'do the impossible', () => {
+todo('do the impossible', () => {
   assert(false);
 });

--- a/test/test-tap.js
+++ b/test/test-tap.js
@@ -11,7 +11,7 @@ it('diagnostic works', () => {
 it('testLine works', () => {
   assert(__Tap__.testLine(true, 1, 'first test') === 'ok - 1 first test');
   assert(__Tap__.testLine(false, 1, 'first test') === 'not ok - 1 first test');
-  assert(__Tap__.testLine(false, 1, 'first test', 'todo', 'because') === 'not ok - 1 first test # todo because');
+  assert(__Tap__.testLine(false, 1, 'first test', 'TODO') === 'not ok - 1 first test # TODO');
 });
 
 it('yaml works', () => {


### PR DESCRIPTION
In particular:

* There’s no longer a “reason” argument for `todo` and `skip`. This
  makes the interface match `it`, which is desirable.
* There’s no longer a form in the reporter. In all the time I’ve spent
  testing, I don’t think I’ve used it once so I removed it.
* The ‘#’ character is considered reserved in descriptions as it creates
  a TAP directive. There’s now a crude guard in place to change that
  character to ‘*’ to prevent weird results.

Additionally, the “test” being run previously was really more of a
“demo”. They’re now split into separate directories. I.e., the demo runs
a test, but the test actually tests our code.