### PR TITLE
Improve root test detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Changed “root” detection to something other than the “id” attribute.
+
 ## [1.0.0] - 2024-02-29
 
 ### Added

--- a/x-test.js
+++ b/x-test.js
@@ -767,7 +767,8 @@ class XTestRoot {
       const error = new Error(`Failed to load ${href}`);
       XTestRoot.bail(context, error);
     });
-    Object.assign(iframe, { id: step.testId, src: href });
+    iframe.setAttribute('data-x-test-test-id', step.testId);
+    Object.assign(iframe, { src: href });
     Object.assign(iframe.style, {
       border: 'none', backgroundColor: 'white', height: '100vh',
       width: '100vw', position: 'fixed', zIndex: '0', top: '0', left: '0',
@@ -1438,7 +1439,7 @@ class XTestSuite {
 
 // There is one-and-only-one root. Either boot as root or child test.
 let suiteContext = null;
-if (frameElement === null || !frameElement.id) {
+if (!frameElement?.getAttribute('data-x-test-test-id')) {
   const state = {
     ended: false, waiting: false, children: [], stepIds: [], steps: {},
     tests: {}, describes: {}, its: {}, coverage: false, coverages: {},
@@ -1456,5 +1457,5 @@ if (frameElement === null || !frameElement.id) {
     state, uuid, publish, subscribe, timeout, addErrorListener,
     addUnhandledrejectionListener,
   };
-  XTestSuite.initialize(suiteContext, frameElement.id, location.href);
+  XTestSuite.initialize(suiteContext, frameElement.getAttribute('data-x-test-test-id'), location.href);
 }


### PR DESCRIPTION
Previously, we looked for a “frameElement.id” property to determine if a document running tests was the “root” test runner or not.

This was too naive as it assumes that integrators looking to iframe a test suite into a part of a parent application _won’t_ set an “id” property / attribute on that iframe.

Instead, we now use a “data-*” attribute with a namespace:

```
data-x-test-test-id
```

See #32.