### PR TITLE
Remove inline “<style>” to pass strict CSP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don’t fail strict integrator CSP rules. Previously, we inlined some <style>
+  tags which would fail for a rule set like `default-src 'self';`. To ensure we
+  don’t reintroduce — strict CSP headers are now added to all test documents.
+
 ## [1.0.1] - 2024-06-14
 
 ### Fixed

--- a/demo/debug/index.html
+++ b/demo/debug/index.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="./index.js"></script>
     <h3>demo debug</h3>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/demo/fail/index.html
+++ b/demo/fail/index.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="./index.js"></script>
     <h3>demo failing</h3>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
     <title>x-test</title>
     <link rel="stylesheet" href="index.css">
     <script type="module" src="index.js"></script>

--- a/demo/nest/index.html
+++ b/demo/nest/index.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="./index.js"></script>
     <h3>demo nesting</h3>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/demo/nest/nested/index.html
+++ b/demo/nest/nested/index.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="index.js"></script>
     <h3>demo nesting, nested</h3>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/demo/nest/nested/nested/index.html
+++ b/demo/nest/nested/nested/index.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="index.js"></script>
     <h3>demo nesting, nested (nested)</h3>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/demo/only/index.html
+++ b/demo/only/index.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="./index.js"></script>
     <h3>demo only</h3>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/demo/pass/index.html
+++ b/demo/pass/index.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="./index.js"></script>
     <h3>demo passing</h3>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/demo/skip/index.html
+++ b/demo/skip/index.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="./index.js"></script>
     <h3>demo skip</h3>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/demo/todo/index.html
+++ b/demo/todo/index.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="./index.js"></script>
     <h3>demo todo</h3>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="index.js"></script>
     <h3>test (all)</h3>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/test/test-reporter.html
+++ b/test/test-reporter.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="test-reporter.js"></script>
     <h3>test-basic</h3>
+    <script type="module" src="test-reporter.js"></script>
   </body>
 </html>

--- a/test/test-root.html
+++ b/test/test-root.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="test-root.js"></script>
     <h3>test-root</h3>
+    <script type="module" src="test-root.js"></script>
   </body>
 </html>

--- a/test/test-scratch.html
+++ b/test/test-scratch.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="test-scratch.js"></script>
     <h3>test-scratch</h3>
+    <script type="module" src="test-scratch.js"></script>
   </body>
 </html>

--- a/test/test-suite.html
+++ b/test/test-suite.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="test-suite.js"></script>
     <h3>test-suite</h3>
+    <script type="module" src="test-suite.js"></script>
   </body>
 </html>

--- a/test/test-tap.html
+++ b/test/test-tap.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
   <body>
-    <meta charset="UTF-8">
-    <script type="module" src="test-tap.js"></script>
     <h3>test-basic</h3>
+    <script type="module" src="test-tap.js"></script>
   </body>
 </html>

--- a/x-test.js
+++ b/x-test.js
@@ -72,209 +72,231 @@ async function timeout(interval) {
   });
 }
 
+const styleSheet = new CSSStyleSheet();
+styleSheet.replaceSync(`
+  :host {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    bottom: 0;
+    width: 100vw;
+    height: 400px;
+    background-color: var(--black);
+    max-height: 100vh;
+    min-height: var(--header-height);
+    font-family: monospace;
+    --header-height: 40px;
+    --black: #111111;
+    --white: white;
+    --subdued: #8C8C8C;
+    --version: #39CCCC;
+    --todo: #FF851B;
+    --todone: #FFDC00;
+    --skip: #FF851B;
+    --ok: #2ECC40;
+    --not-ok: #FF4136;
+    --subtest: #4D4D4D;
+    --plan: #39CCCC;
+    --link: #0085ff;
+  }
+  :host(:not([open])) {
+    max-height: var(--header-height);
+  }
+
+  #header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: var(--header-height);
+    flex-shrink: 0;
+    box-shadow: inset 0 -1px 0 0 #484848, 0 1px 2px 0 #484848;
+    padding-right: 38px;
+    background-color: var(--x-test-reporter-background-color);
+  }
+  :host([open]) #header {
+    cursor: grab;
+  }
+  :host([open][dragging]) #header {
+    cursor: grabbing;
+  }
+
+  #toggle {
+    position: fixed;
+    bottom: 7px;
+    right: 12px;
+    font: inherit;
+    margin: 0;
+    border: none;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 26px;
+    width: 26px;
+    cursor: pointer;
+    --color: var(--subdued);
+    color: var(--color);
+    background-color: transparent;
+    box-shadow: inset 0 0 0 1px var(--color);
+  }
+  #toggle:hover,
+  #toggle:focus-visible {
+    --color: var(--white);
+  }
+  #toggle:active {
+    --color: var(--subdued);
+  }
+  #toggle::before {
+    content: "↑";
+  }
+  :host([open]) #toggle::before {
+    content: "↓";
+  }
+
+  #result {
+    margin: auto 12px;
+    padding: 6px 16px;
+    border-radius: 4px;
+    line-height: 14px;
+    color: var(--white);
+    background-color: var(--todo);
+    user-select: none;
+    pointer-events: none;
+    white-space: nowrap;
+  }
+  #result::before {
+    content: "TESTING...";
+  }
+  :host(:not([ok])) #result {
+    background-color: var(--not-ok);
+  }
+  :host(:not([ok])) #result::before {
+    content: "NOT OK!";
+  }
+  :host([ok]:not([testing])) #result {
+    background-color: var(--ok);
+  }
+  :host([ok]:not([testing])) #result::before {
+    content: "OK!";
+  }
+
+  #tag-line {
+    margin: auto 12px;
+    color: var(--subdued);
+    cursor: default;
+    user-select: none;
+    pointer-events: none;
+  }
+
+  #body {
+    flex: 1;
+    overflow: auto;
+    display: flex;
+    /* Flip top/bottom for console-like scroll behavior. */
+    flex-direction: column-reverse;
+    box-sizing: border-box;
+  }
+  :host([dragging]) #body {
+    pointer-events: none;
+  }
+
+  #spacer {
+    flex: 1;
+  }
+
+  [output] {
+    white-space: pre;
+    color: var(--subdued);
+    line-height: 20px;
+    padding: 0 12px;
+    cursor: default;
+  }
+  [output]:first-child {
+    padding-top: 12px;
+  }
+  [output]:last-child {
+    padding-bottom: 12px;
+  }
+
+  [yaml] {
+    line-height: 16px;
+  }
+
+  a[output]:any-link {
+    display: block;
+    width: min-content;
+    cursor: pointer;
+  }
+
+  [it][ok]:not([directive]) {
+    color: var(--ok);
+  }
+  [it]:not([ok]):not([directive]),
+  [bail] {
+    color: var(--not-ok);
+  }
+  [it][ok][directive="skip"] {
+    color: var(--skip);
+  }
+  [it]:not([ok])[directive="todo"] {
+    color: var(--todo);
+  }
+  [it][ok][directive="todo"] {
+    color: var(--todone);
+  }
+
+  [plan][indent],
+  [plan] + [it][ok]:not([directive]),
+  [plan] + [it]:not([ok]):not([directive]),
+  [plan] + [it][ok][directive="skip"],
+  [plan] + [it]:not([ok])[directive="todo"],
+  [plan] + [it][ok][directive="todo"] {
+    color: var(--subdued);
+  }
+
+  [version] {
+    color: var(--version);
+  }
+
+  [plan] {
+    color: var(--plan);
+  }
+
+  a[subtest]:not([bail]) {
+    color: var(--link);
+  }
+
+  [subtest]:not([bail]) {
+    color: var(--subdued);
+  }
+
+  [indent] {
+    position: relative;
+  }
+  [indent]::before {
+    position: absolute;
+    content: attr(indent);
+    color: var(--subdued);
+    opacity: 0.25;
+  }
+`);
+
+const template = document.createElement('template');
+template.setHTMLUnsafe(`
+  <div id="header"><div id="result"></div><div id="tag-line">x-test - a simple, tap-compliant test runner for the browser.</div></div>
+  <div id="body"><div id="spacer"></div><div id="container"></div></div>
+  <button id="toggle" type="button"></button>
+`);
+
 class XTestReporter extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
-    this.shadowRoot.innerHTML = `\
-      <style>
-        :host {
-          display: flex;
-          flex-direction: column;
-          justify-content: flex-end;
-          position: fixed;
-          z-index: 1;
-          left: 0;
-          bottom: 0;
-          width: 100vw;
-          height: 400px;
-          background-color: var(--black);
-          max-height: 100vh;
-          min-height: var(--header-height);
-          font-family: monospace;
-          --header-height: 40px;
-          --black: #111111;
-          --white: white;
-          --subdued: #8C8C8C;
-          --version: #39CCCC;
-          --todo: #FF851B;
-          --todone: #FFDC00;
-          --skip: #FF851B;
-          --ok: #2ECC40;
-          --not-ok: #FF4136;
-          --subtest: #4D4D4D;
-          --plan: #39CCCC;
-          --link: #0085ff;
-        }
-        :host(:not([open])) {
-          max-height: var(--header-height);
-        }
-        #header {
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          height: var(--header-height);
-          flex-shrink: 0;
-          box-shadow: inset 0 -1px 0 0 #484848, 0 1px 2px 0 #484848;
-          padding-right: 38px;
-          background-color: var(--x-test-reporter-background-color);
-        }
-        :host([open]) #header {
-          cursor: grab;
-        }
-        :host([open][dragging]) #header {
-          cursor: grabbing;
-        }
-        #toggle {
-          position: fixed;
-          bottom: 7px;
-          right: 12px;
-          font: inherit;
-          margin: 0;
-          border: none;
-          border-radius: 4px;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          height: 26px;
-          width: 26px;
-          cursor: pointer;
-          --color: var(--subdued);
-          color: var(--color);
-          background-color: transparent;
-          box-shadow: inset 0 0 0 1px var(--color);
-        }
-        #toggle:hover,
-        #toggle:focus-visible {
-          --color: var(--white);
-        }
-        #toggle:active {
-          --color: var(--subdued);
-        }
-        #toggle::before {
-          content: "↑";
-        }
-        :host([open]) #toggle::before {
-          content: "↓";
-        }
-        #result {
-          margin: auto 12px;
-          padding: 6px 16px;
-          border-radius: 4px;
-          line-height: 14px;
-          color: var(--white);
-          background-color: var(--todo);
-          user-select: none;
-          pointer-events: none;
-          white-space: nowrap;
-        }
-        #result::before {
-          content: "TESTING...";
-        }
-        :host(:not([ok])) #result {
-          background-color: var(--not-ok);
-        }
-        :host(:not([ok])) #result::before {
-          content: "NOT OK!";
-        }
-        :host([ok]:not([testing])) #result {
-          background-color: var(--ok);
-        }
-        :host([ok]:not([testing])) #result::before {
-          content: "OK!";
-        }
-        #tag-line {
-          margin: auto 12px;
-          color: var(--subdued);
-          cursor: default;
-          user-select: none;
-          pointer-events: none;
-        }
-        #body {
-          flex: 1;
-          overflow: auto;
-          display: flex;
-          /* Flip top/bottom for console-like scroll behavior. */
-          flex-direction: column-reverse;
-          box-sizing: border-box;
-        }
-        :host([dragging]) #body {
-          pointer-events: none;
-        }
-        #spacer {
-          flex: 1;
-        }
-        [output] {
-          white-space: pre;
-          color: var(--subdued);
-          line-height: 20px;
-          padding: 0 12px;
-          cursor: default;
-        }
-        [output]:first-child {
-          padding-top: 12px;
-        }
-        [output]:last-child {
-          padding-bottom: 12px;
-        }
-        [yaml] {
-          line-height: 16px;
-        }
-        a[output]:any-link {
-          display: block;
-          width: min-content;
-          cursor: pointer;
-        }
-        [it][ok]:not([directive]) {
-          color: var(--ok);
-        }
-        [it]:not([ok]):not([directive]),
-        [bail] {
-          color: var(--not-ok);
-        }
-        [it][ok][directive="skip"] {
-          color: var(--skip);
-        }
-        [it]:not([ok])[directive="todo"] {
-          color: var(--todo);
-        }
-        [it][ok][directive="todo"] {
-          color: var(--todone);
-        }
-        [plan][indent],
-        [plan] + [it][ok]:not([directive]),
-        [plan] + [it]:not([ok]):not([directive]),
-        [plan] + [it][ok][directive="skip"],
-        [plan] + [it]:not([ok])[directive="todo"],
-        [plan] + [it][ok][directive="todo"] {
-          color: var(--subdued);
-        }
-        [version] {
-          color: var(--version);
-        }
-        [plan] {
-          color: var(--plan);
-        }
-        a[subtest]:not([bail]) {
-          color: var(--link);
-        }
-        [subtest]:not([bail]) {
-          color: var(--subdued);
-        }
-        [indent] {
-          position: relative;
-        }
-        [indent]::before {
-          position: absolute;
-          content: attr(indent);
-          color: var(--subdued);
-          opacity: 0.25;
-        }
-      </style>
-      <div id="header"><div id="result"></div><div id="tag-line">x-test - a simple, tap-compliant test runner for the browser.</div></div>
-      <div id="body"><div id="spacer"></div><div id="container"></div></div>
-      <button id="toggle" type="button"></button>
-    `;
+    this.shadowRoot.adoptedStyleSheets = [styleSheet];
+    this.shadowRoot.append(template.content.cloneNode(true));
   }
 
   connectedCallback() {


### PR DESCRIPTION
Some integrators will want to lock down html documents with strict content security policy rules — there’s no reason that this testing library should get in the way of stricter policies!

Closes #45.