### PR TITLE
Add filtering based on “x-test-name” param.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds “node/x-test-client-*” files to greatly simplify the glue code required
   by integrators to run tests in `node`. Integrators simply import the right
   client and call `run()` (#53).
+- Adds “x-test-name” query param to enable filtering of tests based on the given
+  pattern name. This is done internally so it will work in both a browser and
+  a CLI output (#58).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ The following parameters can be passed in via query params on the url:
 
 - `x-test-no-reporter`: turns off custom reporting tool ui
 - `x-test-run-coverage`: turns on coverage reporting**
+- `x-test-name`: filters tests by name using regex pattern matching**
 
 **See `test.js` for an example of how to capture coverage information in
 puppeteer and send it to your test to allow your automated test to fail due to
-unmet coverage goals.
+unmet coverage goals. The `x-test-name` parameter filters tests by matching the full test name (including parent describe blocks) against the provided regex pattern.
 
 ## Execution
 
@@ -65,13 +66,32 @@ given html page in an iframe. Such iframes are run one-at-a-time. All invoked
 
 **This is not the case if you nest `it`--but that's an anti-pattern anyhow.
 
+## Test Filtering
+
+You can filter tests by name using the `x-test-name` query parameter, which accepts a regex pattern. This allows you to run only specific tests that match the pattern.
+
+### Browser Usage
+```
+http://localhost:8080/test/?x-test-name=should%20validate
+```
+
+### Command Line Usage
+When using the Puppeteer or Playwright clients, you can use the `--testName` argument:
+
+```bash
+node node/test-puppeteer-chrome.js --testName="should validate"
+node node/test-playwright-chromium.js --testName="user.*login"
+```
+
+The pattern will match against the full test name, including any parent `describe` block names joined with spaces.
+
 ## Usage with `puppeteer` or `playwright`
 
 See `node/x-test-client-puppeteer.js` for an example of how you can use
-`puppeteer` to run your app’s tests and log the resulting TAP output.
+`puppeteer` to run your app's tests and log the resulting TAP output.
 
 See `node/x-test-client-playwright.js` for an example of how you can use
-`playwright` to run your app’s tests and log the resulting TAP output.
+`playwright` to run your app's tests and log the resulting TAP output.
 
 ## Parsing TAP
 

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "playwright:install": "playwright install --with-deps",
     "test": "npm run test:puppeteer",
     "test:puppeteer": "npm run test:puppeteer:chrome",
-    "test:puppeteer:chrome": "node node/test-puppeteer-chrome.js | tap-parser -l",
+    "test:puppeteer:chrome": "node node/test-puppeteer-chrome.js",
     "test:playwright": "npm run test:playwright:chromium && npm run test:playwright:firefox && npm run test:playwright:webkit",
-    "test:playwright:chromium": "node node/test-playwright-chromium.js | tap-parser -l",
-    "test:playwright:firefox": "node node/test-playwright-firefox.js | tap-parser -l",
-    "test:playwright:webkit": "node node/test-playwright-webkit.js | tap-parser -l",
+    "test:playwright:chromium": "node node/test-playwright-chromium.js",
+    "test:playwright:firefox": "node node/test-playwright-firefox.js",
+    "test:playwright:webkit": "node node/test-playwright-webkit.js",
     "bump": "./bump.sh"
   },
   "files": [

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 import { test, coverage } from '../x-test.js';
 
-coverage('../x-test-reporter.js', 74);
-coverage('../x-test-root.js', 82);
+coverage('../x-test-reporter.js', 70);
+coverage('../x-test-root.js', 71);
 coverage('../x-test-suite.js', 96);
 coverage('../x-test-tap.js', 100);
 coverage('../x-test.js', 100);

--- a/x-test-reporter.css.js
+++ b/x-test-reporter.css.js
@@ -41,7 +41,7 @@ styleSheet.replaceSync(css`
   height: var(--header-height);
   flex-shrink: 0;
   box-shadow: inset 0 -1px 0 0 #484848, 0 1px 2px 0 #484848;
-  padding-right: 38px;
+  padding-right: 54px;
   background-color: var(--x-test-reporter-background-color);
 }
 :host([open]) #header {
@@ -111,12 +111,9 @@ styleSheet.replaceSync(css`
   content: "OK!";
 }
 
-#tag-line {
-  margin: auto 12px;
-  color: var(--subdued);
-  cursor: default;
-  user-select: none;
-  pointer-events: none;
+#form {
+  display: flex;
+  gap: 2px;
 }
 
 #body {

--- a/x-test-reporter.js
+++ b/x-test-reporter.js
@@ -2,7 +2,7 @@ import styleSheet from './x-test-reporter.css.js';
 
 const template = document.createElement('template');
 template.setHTMLUnsafe(`
-  <div id="header"><div id="result"></div><div id="tag-line">x-test - a simple, tap-compliant test runner for the browser.</div></div>
+  <div id="header"><div id="result"></div><form id="form"><input id="test-name" name="testName" autofocus placeholder="Filter by name&hellip;"><input id="reset" type=reset value="&#x21BA;"></form></div>
   <div id="body"><div id="spacer"></div><div id="container"></div></div>
   <button id="toggle" type="button"></button>
 `);
@@ -22,6 +22,7 @@ export class XTestReporter extends HTMLElement {
     if (localStorage.getItem('x-test-reporter-closed') !== 'true') {
       this.setAttribute('open', '');
     }
+    this.shadowRoot.getElementById('test-name').value = new URL(location.href).searchParams.get('x-test-name') ?? '';
     this.shadowRoot.getElementById('toggle').addEventListener('click', () => {
       this.hasAttribute('open') ? this.removeAttribute('open') : this.setAttribute('open', '');
       localStorage.setItem('x-test-reporter-closed', String(!this.hasAttribute('open')));
@@ -33,6 +34,23 @@ export class XTestReporter extends HTMLElement {
       this.style.height = `${Math.round(currentHeight + currentHeaderY - nextHeaderY)}px`;
       localStorage.setItem('x-test-reporter-height', this.style.height);
     };
+    this.shadowRoot.getElementById('form').addEventListener('reset', () => {
+      const url = new URL(location.href);
+      url.searchParams.delete('x-test-name');
+      location.href = url.href;
+    });
+    this.shadowRoot.getElementById('form').addEventListener('submit', event => {
+      event.preventDefault();
+      const formData = new FormData(event.target);
+      const testName = formData.get('testName');
+      const url = new URL(location.href);
+      if (testName) {
+        url.searchParams.set('x-test-name', testName);
+      } else {
+        url.searchParams.delete('x-test-name');
+      }
+      location.href = url.href;
+    });
     this.shadowRoot.getElementById('header').addEventListener('pointerdown', event => {
       if (this.hasAttribute('open')) {
         const headerY = this.shadowRoot.getElementById('header').getBoundingClientRect().y;

--- a/x-test.js
+++ b/x-test.js
@@ -84,7 +84,8 @@ if (!frameElement?.getAttribute('data-x-test-test-id')) {
     ended: false, waiting: false, children: [], stepIds: [], steps: {},
     tests: {}, describes: {}, its: {}, coverage: false, coverages: {},
     resolveCoverageValuePromise: null, coverageValuePromise: null,
-    coverageValue: null, reporter: null,
+    coverageValue: null, reporter: null, filtering: false, queue: [],
+    queueing: false,
   };
   const rootContext = { state, uuid, publish, subscribe, timeout };
   XTestRoot.initialize(rootContext, location.href);


### PR DESCRIPTION
A new `?x-test-name` param is accepted as a query parameter which will cause `x-test` to go into “filtering” mode. In this mode, any test lines which do not match the provided name (and empty subtests) will be omitted from the output stream entirely.

This means that the parameter impacts the browser output and the CLI output equally. I.e., you can use this filtering in the command line or via the new input box in the UI.

Closes #58.

<img width="1265" height="1264" alt="Screenshot 2025-08-01 at 10 47 19 PM" src="https://github.com/user-attachments/assets/8748aa3d-2d54-4482-8900-fbbd73697b3d" />

<img width="1019" height="775" alt="Screenshot 2025-08-01 at 10 50 54 PM" src="https://github.com/user-attachments/assets/56c1e349-51cc-4f1e-974d-aaae24e445b3" />
