### PR TITLE
Fix “bump.sh” script for workspaces.

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -19,10 +19,10 @@ by running `git checkout main && git pull origin main`.
 1. Edit version in **both** package.json files:
    - Root `package.json` (for `@netflix/x-test`)
    - `client/package.json` (for `@netflix/x-test-client`)
-   - Also update `package-lock.json` and `jsr.json` files
+   - Also update the `package-lock.json` file and the `jsr.json` files
 
-   Don't forget that `package-lock.json` should be edited in multiple places to
-   account for workspace versions. For example, set the “version” key to
+   Don't forget that the `package-lock.json` should be edited in multiple places
+   to account for workspace versions. For example, set the “version” key to
    “1.0.0-rc.57” in both package.json files.
 
 2. Add / commit those files. By convention, set the message to the new version

--- a/bump.sh
+++ b/bump.sh
@@ -18,8 +18,8 @@ fi
 # Bump version in “package.json” files using npm version itself. This ensures
 #  that we stay anchored to first-class tooling. Pass “--git-tag-version=false”
 #  to prevent the command from (1) committing changes and (2) creating a tag.
-prefixed_version="$(npm version --git-tag-version=false "${1}")"
-prefixed_client_version="$(npm version --git-tag-version=false --workspace=@netflix/x-test-client "${1}")"
+prefixed_version="$(npm version --git-tag-version=false "${1}" | grep "^v")"
+prefixed_client_version="$(npm version --git-tag-version=false --workspace=@netflix/x-test-client "${1}" | grep "^v")"
 
 # Validate that both packages have the same version.
 if [ "${prefixed_version}" != "${prefixed_client_version}" ]
@@ -41,7 +41,6 @@ package_lock_json_file="${root_directory}/package-lock.json"
 client_directory="${root_directory}/client"
 client_jsr_json_file="${client_directory}/jsr.json"
 client_package_json_file="${client_directory}/package.json"
-client_package_lock_json_file="${client_directory}/package-lock.json"
 
 # Bump version in “jsr.json” files.
 jsr_json_find="\"version\": \"[^\"]*\""
@@ -58,7 +57,6 @@ git add "${package_json_file}"
 git add "${package_lock_json_file}"
 git add "${jsr_json_file}"
 git add "${client_package_json_file}"
-git add "${client_package_lock_json_file}"
 git add "${client_jsr_json_file}"
 git commit --message="${version}"
 git tag --annotate "v${version}" --message="${version}"


### PR DESCRIPTION
Minor change to fix our validation that confirms both packages get published with the exact same version.

And, removed handling client/package-lock.json in “bump.sh”.

And, update the “PUBLISHING.md” file.