### PR TITLE
Aligns published package files with x-element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-  The “/test” and “/demo” files are restored in the published file set.
+
 ## [2.0.0-rc.3] - 2025-11-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -29,14 +29,15 @@
     "bump": "./bump.sh"
   },
   "files": [
-    "LICENSE",
-    "/types/x-test.d.ts",
     "/x-test-reporter.css.js",
     "/x-test-reporter.js",
     "/x-test-root.js",
     "/x-test-suite.js",
     "/x-test-tap.js",
-    "/x-test.js"
+    "/x-test.js",
+    "/demo",
+    "/test",
+    "/types"
   ],
   "devDependencies": {
     "@netflix/eslint-config": "^3.0.0",


### PR DESCRIPTION
Fixes #71

Makes the `x-test` `package.json` align with https://github.com/Netflix/x-element/blob/d396ddd091d13b5938bc1e21f91cd1ad5eeb49b2/package.json#L42-L49

![gimme](https://github.com/user-attachments/assets/e594f068-46db-42fe-afbe-6aad5c783888)

