### PR TITLE
Add GH environment for publish and update actions.

### DIFF
--- a/.github/workflows/publish-to-jsr.yaml
+++ b/.github/workflows/publish-to-jsr.yaml
@@ -8,8 +8,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20.18'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -5,13 +5,13 @@ on: [workflow_call]
 jobs:
   main:
     runs-on: ubuntu-latest
+    environment: npm-publish
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20.18'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
       - run: npm publish
         env:
           # The secrets should be implicitly passed via “secrets: inherit”.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,8 @@ jobs:
     needs: test
     uses: ./.github/workflows/publish-to-npm.yaml
     secrets: inherit
-  publish-to-jsr:
-    needs: test
-    uses: ./.github/workflows/publish-to-jsr.yaml
-    secrets: inherit
+  # Disabled for now as we sort out “environment” support.
+  # publish-to-jsr:
+  #   needs: test
+  #   uses: ./.github/workflows/publish-to-jsr.yaml
+  #   secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,8 +5,8 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20.18'
           registry-url: 'https://registry.npmjs.org'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- NPM token lives in a GH environment for publish action (more secure).
+
 ## [2.0.0-rc.4] - 2026-01-09
 
 ### Added
 
--  The “/test” and “/demo” files are restored in the published file set.
+- The “/test” and “/demo” files are restored in the published file set.
 
 ## [2.0.0-rc.3] - 2025-11-06
 


### PR DESCRIPTION
Changes:
1. Add a “publish” environment which can be targeted with a more narrowly scoped NPM token.
2. Update all the GH actions to latest versions.