### PR TITLE
Make TS recognize “assert” as true assertion.

### DIFF
--- a/types/x-test.d.ts
+++ b/types/x-test.d.ts
@@ -1,4 +1,4 @@
-export function assert(ok: unknown, text?: string): void;
+export function assert(ok: unknown, text?: string): asserts ok;
 export function coverage(href: string, goal: number): void;
 export function waitFor(promise: Promise<unknown>): Promise<void>;
 export function test(href: string): void;

--- a/x-test.js
+++ b/x-test.js
@@ -8,7 +8,7 @@ import { XTestSuite } from './x-test-suite.js';
  *   assert('foo' === 'bar', 'foo does not equal bar');
  * @param {unknown} ok - The condition to assert (truthy/falsy)
  * @param {string} [text] - The assertion message
- * @returns {void}
+ * @returns {asserts ok} Throws if condition is falsy.
  */
 export const assert = (ok, text) => XTestSuite.assert(suiteContext, ok, text);
 


### PR DESCRIPTION
By hinting to TypeScript that this function is a true assertion, we let downstream integrators benefit from easier type narrowing. I.e., we let TypeScript know that the condition _must hold_ on subsequent lines since the `assert` function is guaranteed to throw if the condition fails. †

† Note, technically, we silently bail on this if the suite has already
  failed to prevent noise in the testing results. I.e., we skip this
  check if the test has already bailed or something. The TAP
  specification requires that we stop printing new info after a
  “Bail out!” line, which is why we do this.