### PR TITLE
Fix failures from multiple inclusions of “x-test”.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Multiple `<script type="module">` tags in one HTML file now all
+  register tests into the same suite. Previously only the first
+  script’s registrations survived; the rest were silently dropped (#81).
+
 ## [2.0.0-rc.6] - 2026-03-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bump": "./bump.sh"
   },
   "files": [
+    "/x-test-common.js",
     "/x-test-reporter.css.js",
     "/x-test-reporter.js",
     "/x-test-root.js",

--- a/test/index.js
+++ b/test/index.js
@@ -10,4 +10,6 @@ test('./test-reporter.html');
 test('./test-suite.html');
 test('./test-root.html');
 test('./test-tap.html');
+test('./test-common.html');
+test('./test-boot.html');
 test('./test-scratch.html');

--- a/test/test-boot-a.js
+++ b/test/test-boot-a.js
@@ -1,0 +1,7 @@
+import { it, describe, assert } from '../x-test.js';
+
+describe('<script type="module"> in <head>', () => {
+  it('registers into the same suite as body-placed scripts', () => {
+    assert(true);
+  });
+});

--- a/test/test-boot-b.js
+++ b/test/test-boot-b.js
@@ -1,0 +1,7 @@
+import { it, describe, assert } from '../x-test.js';
+
+describe('first <script type="module"> in <body>', () => {
+  it('registers tests', () => {
+    assert(true);
+  });
+});

--- a/test/test-boot-c.js
+++ b/test/test-boot-c.js
@@ -1,0 +1,7 @@
+import { it, describe, assert } from '../x-test.js';
+
+describe('second <script type="module"> in <body>', () => {
+  it('is not silently dropped after the first script evaluates', () => {
+    assert(true);
+  });
+});

--- a/test/test-boot.html
+++ b/test/test-boot.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <!--
+      This suite documents how x-test boots across every supported
+      <script type="module"> arrangement: head placement, body placement,
+      multiple sibling scripts contributing to the same suite, and an
+      inline module script.
+
+      The invariant holding it all together: x-test keeps the registration
+      window open until DOMContentLoaded fires, which happens *after* every
+      deferred module script has synchronously evaluated. Any combination
+      of these arrangements registers into a single suite.
+    -->
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-Tr3Xl0Jk5gT59jVAgb3/Gh7rLeEEE/DdwKxzketLPAU=';">
+
+    <!-- Supports “x-test” loaded in <head>. -->
+    <script type="module" src="../x-test.js"></script>
+
+    <!-- Supports a user test script placed in <head>. -->
+    <script type="module" src="test-boot-a.js"></script>
+  </head>
+  <body>
+    <h3>test-boot</h3>
+
+    <!-- Support a user test script placed in <body>. -->
+    <script type="module" src="test-boot-b.js"></script>
+
+    <!-- Supports multiple user scripts in <body>. -->
+    <script type="module" src="test-boot-c.js"></script>
+
+    <!-- Support inline module scripts. -->
+    <script type="module">
+      import { it, describe, assert } from '../x-test.js';
+
+      describe('inline <script type="module">', () => {
+        it('registers alongside src-backed scripts', () => {
+          assert(true);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/test/test-common.html
+++ b/test/test-common.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
+  <body>
+    <h3>test-common</h3>
+    <script type="module" src="test-common.js"></script>
+  </body>
+</html>

--- a/test/test-common.js
+++ b/test/test-common.js
@@ -1,0 +1,37 @@
+import { it, describe, assert } from '../x-test.js';
+import { XTestCommon } from '../x-test-common.js';
+
+// A minimal fake target that records handlers so tests can fire events
+//  deterministically. The “domContentLoadedPromise” helper accepts any
+//  EventTarget-like object — this is the dependency-injection surface.
+const makeFakeTarget = (extra = {}) => {
+  const handlers = {};
+  return {
+    handlers,
+    addEventListener(type, handler) { handlers[type] = handler; },
+    ...extra,
+  };
+};
+
+describe('timeout', () => {
+  it('resolves with XTestCommon.TIMEOUT after the interval', async () => {
+    const result = await XTestCommon.timeout(1);
+    assert(result === XTestCommon.TIMEOUT);
+  });
+});
+
+describe('domContentLoadedPromise', () => {
+  it('resolves immediately when readyState is "complete"', async () => {
+    const fake = makeFakeTarget({ readyState: 'complete' });
+    const result = await XTestCommon.domContentLoadedPromise(/** @type {Document} */ (fake));
+    assert(result === undefined);
+  });
+
+  it('resolves on DOMContentLoaded when readyState is not "complete"', async () => {
+    const fake = makeFakeTarget({ readyState: 'loading' });
+    const promise = XTestCommon.domContentLoadedPromise(/** @type {Document} */ (fake));
+    fake.handlers.DOMContentLoaded();
+    const result = await promise;
+    assert(result === undefined);
+  });
+});

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -66,7 +66,8 @@ const getContext = () => {
   addUnhandledrejectionListener.callbacks = [];
   injectError.calls = [];
   injectUnhandledrejection.calls = [];
-  const context = { state, uuid, publish, subscribe, timeout, addErrorListener, addUnhandledrejectionListener };
+  const domContentLoadedPromise = Promise.resolve();
+  const context = { state, uuid, publish, subscribe, timeout, addErrorListener, addUnhandledrejectionListener, domContentLoadedPromise };
   return { context, injectError, injectUnhandledrejection };
 };
 

--- a/types/x-test-common.d.ts
+++ b/types/x-test-common.d.ts
@@ -1,0 +1,14 @@
+export class XTestCommon {
+    static TIMEOUT: symbol;
+    /**
+     * @param {number} interval - The timeout duration in milliseconds.
+     * @returns {Promise<symbol>} Resolves to XTestCommon.TIMEOUT after interval.
+     */
+    static timeout(interval: number): Promise<symbol>;
+    /**
+     * Promise that resolves at DOMContentLoaded.
+     * @param {Document} doc - Takes a parameter so tests can swap in a mock.
+     * @returns {Promise<void>}
+     */
+    static domContentLoadedPromise(doc: Document): Promise<void>;
+}

--- a/x-test-common.js
+++ b/x-test-common.js
@@ -1,0 +1,28 @@
+export class XTestCommon {
+  static TIMEOUT = Symbol('timeout');
+
+  /**
+   * @param {number} interval - The timeout duration in milliseconds.
+   * @returns {Promise<symbol>} Resolves to XTestCommon.TIMEOUT after interval.
+   */
+  static async timeout(interval) {
+    return await new Promise(resolve => {
+      setTimeout(() => { resolve(XTestCommon.TIMEOUT); }, interval);
+    });
+  }
+
+  /**
+   * Promise that resolves at DOMContentLoaded.
+   * @param {Document} doc - Takes a parameter so tests can swap in a mock.
+   * @returns {Promise<void>}
+   */
+  static domContentLoadedPromise(doc) {
+    return new Promise(resolve => {
+      if (doc.readyState === 'complete') {
+        resolve(undefined);
+      } else {
+        doc.addEventListener('DOMContentLoaded', () => resolve(undefined), { once: true });
+      }
+    });
+  }
+}

--- a/x-test-suite.js
+++ b/x-test-suite.js
@@ -1,6 +1,6 @@
-export class XTestSuite {
-  static timeout = Symbol('timeout');
+import { XTestCommon } from './x-test-common.js';
 
+export class XTestSuite {
   /**
    * @param {any} context
    * @param {any} testId
@@ -32,8 +32,8 @@ export class XTestSuite {
       XTestSuite.bail(context, event.reason);
     });
 
-    // Await a single microtask before we signal that we're ready.
-    XTestSuite.waitFor(context, Promise.resolve());
+    // Keep registration open until _at least_ DOMContentLoaded.
+    XTestSuite.waitFor(context, context.domContentLoadedPromise);
   }
 
   /**
@@ -60,7 +60,7 @@ export class XTestSuite {
           const callback = context.state.callbacks[itId];
           const resolvedInterval = interval ?? 30_000;
           const timeout = await Promise.race([callback(), context.timeout(resolvedInterval)]);
-          if (timeout === XTestSuite.timeout) {
+          if (timeout === XTestCommon.TIMEOUT) {
             throw new Error(`timeout after ${resolvedInterval.toLocaleString()}ms`);
           }
         }

--- a/x-test.js
+++ b/x-test.js
@@ -1,3 +1,4 @@
+import { XTestCommon } from './x-test-common.js';
 import { XTestRoot } from './x-test-root.js';
 import { XTestSuite } from './x-test-suite.js';
 
@@ -159,16 +160,6 @@ function addUnhandledrejectionListener(callback) {
   addEventListener('unhandledrejection', callback);
 }
 
-/**
- * @param {number} interval - The timeout duration in milliseconds
- * @returns {Promise<symbol>} Promise resolving to timeout symbol
- */
-async function timeout(interval) {
-  return await new Promise(resolve => {
-    setTimeout(() => { resolve(XTestSuite.timeout); }, interval);
-  });
-}
-
 // There is one-and-only-one root. Either boot as root or child test.
 /** @type {unknown} */
 let suiteContext = null;
@@ -180,16 +171,17 @@ if (!frameElement?.getAttribute('data-x-test-test-id')) {
     coverageValue: null, reporter: null, filtering: false, queue: [],
     queueing: false,
   };
-  const rootContext = { state, uuid, publish, subscribe, timeout };
+  const rootContext = { state, uuid, publish, subscribe, timeout: XTestCommon.timeout };
   XTestRoot.initialize(rootContext, location.href);
 } else {
   const state = {
     testId: null, href: null, callbacks: {}, bailed: false, waitForId: null,
     ready: false, promises: [], parents: [],
   };
+  const domContentLoadedPromise = XTestCommon.domContentLoadedPromise(document);
   suiteContext = {
-    state, uuid, publish, subscribe, timeout, addErrorListener,
-    addUnhandledrejectionListener,
+    state, uuid, publish, subscribe, timeout: XTestCommon.timeout, addErrorListener,
+    addUnhandledrejectionListener, domContentLoadedPromise,
   };
   XTestSuite.initialize(suiteContext, frameElement.getAttribute('data-x-test-test-id'), location.href);
 }


### PR DESCRIPTION
This change set moves our registration gate from being a microtask via `Promise.resolve()` to an await on `DOMContentLoaded`. This allows all imports (which are deferred as modules) to register via the standard `test` / `describe` / `it` calls _before_ the window closes.

It fixes the following concrete cases:

- Multiple test scripts included in HTML document (HEAD/BODY/inline).
- Performance optimizations to pull “x-test” into HEAD import.

Closes #81.