### PR TITLE
Fix handling of problematic iframe loads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Iframes pointed at bad URLs (404, 500, SPA fallbacks, unreachable
+  hosts) now fail cleanly with a clear error instead of silently
+  passing as `1..0 ok` or hanging (#82).
 - Multiple `<script type="module">` tags in one HTML file now all
   register tests into the same suite. Previously only the first
   script’s registrations survived; the rest were silently dropped (#81).

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Messages are posted to a `BroadcastChannel` channel with the name `x-test`.
 - `x-test-client-coverage-result`: response to `x-test-root-coverage-request`
 - `x-test-root-end`: all tests have completed or we bailed out
 - (internal) `x-test-root-run`: all tests have completed or we bailed out
+- (internal) `x-test-root-defer`: defer work until round-trip through BroadcastChannel queue
+- (internal) `x-test-suite-initialize`: published the moment suite it boots for tracking load success
 - (internal) `x-test-suite-coverage`: signal to test for coverage on a particular file
 - (internal) `x-test-suite-register`: registers a new test / describe / it
 - (internal) `x-test-suite-ready`: signal that test suite is done with registration

--- a/test/test-common.js
+++ b/test/test-common.js
@@ -35,3 +35,23 @@ describe('domContentLoadedPromise', () => {
     assert(result === undefined);
   });
 });
+
+describe('iframeError', () => {
+  it('resolves with XTestCommon.IFRAME_ERROR when the error event fires', async () => {
+    const fake = makeFakeTarget();
+    const promise = XTestCommon.iframeError(fake);
+    fake.handlers.error();
+    const result = await promise;
+    assert(result === XTestCommon.IFRAME_ERROR);
+  });
+});
+
+describe('iframeLoad', () => {
+  it('resolves with XTestCommon.IFRAME_LOAD when the load event fires', async () => {
+    const fake = makeFakeTarget();
+    const promise = XTestCommon.iframeLoad(fake);
+    fake.handlers.load();
+    const result = await promise;
+    assert(result === XTestCommon.IFRAME_LOAD);
+  });
+});

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -82,15 +82,17 @@ describe('initialize', () => {
     assert(context.state.parents[0].testId === '123');
     assert(context.addErrorListener.calls.length === 1);
     assert(context.addUnhandledrejectionListener.calls.length === 1);
-    assert(context.publish.calls.length === 0);
+    assert(context.publish.calls.length === 1);
+    assert(context.publish.calls[0][0] === 'x-test-suite-initialize');
+    assert(context.publish.calls[0][1].testId === '123');
     assert(context.state.waitForId === '0');
     assert(context.state.promises.length === 1);
     assert(context.state.ready === false);
     await Promise.all(context.state.promises);
     assert(context.state.ready === true);
-    assert(context.publish.calls.length === 1);
-    assert(context.publish.calls[0][0] === 'x-test-suite-ready');
-    assert(context.publish.calls[0][1].testId === '123');
+    assert(context.publish.calls.length === 2);
+    assert(context.publish.calls[1][0] === 'x-test-suite-ready');
+    assert(context.publish.calls[1][1].testId === '123');
   });
 
   it('marks state as bailed when any test bails', async () => {
@@ -111,13 +113,14 @@ describe('initialize', () => {
     context.publish('x-test-root-run', { itId: 'testItId' });
     assert(called === true);
     await new Promise(resolve => setTimeout(resolve));
-    assert(context.publish.calls.length === 3);
-    assert(context.publish.calls[0][0] === 'x-test-suite-ready'); // This is from initialization.
-    assert(context.publish.calls[1][0] === 'x-test-root-run'); // This is from our test.
-    assert(context.publish.calls[2][0] === 'x-test-suite-result');
-    assert(context.publish.calls[2][1].itId === 'testItId');
-    assert(context.publish.calls[2][1].ok === true);
-    assert(context.publish.calls[2][1].error === null);
+    assert(context.publish.calls.length === 4);
+    assert(context.publish.calls[0][0] === 'x-test-suite-initialize'); // From initialization (sync).
+    assert(context.publish.calls[1][0] === 'x-test-suite-ready'); // From initialization (async).
+    assert(context.publish.calls[2][0] === 'x-test-root-run'); // This is from our test.
+    assert(context.publish.calls[3][0] === 'x-test-suite-result');
+    assert(context.publish.calls[3][1].itId === 'testItId');
+    assert(context.publish.calls[3][1].ok === true);
+    assert(context.publish.calls[3][1].error === null);
   });
 
   it('runs a test when told, skip', async () => {
@@ -130,13 +133,14 @@ describe('initialize', () => {
     context.publish('x-test-root-run', { itId: 'testItId', directive: 'SKIP' });
     assert(called === false);
     await new Promise(resolve => setTimeout(resolve));
-    assert(context.publish.calls.length === 3);
-    assert(context.publish.calls[0][0] === 'x-test-suite-ready'); // This is from initialization.
-    assert(context.publish.calls[1][0] === 'x-test-root-run'); // This is from our test.
-    assert(context.publish.calls[2][0] === 'x-test-suite-result');
-    assert(context.publish.calls[2][1].itId === 'testItId');
-    assert(context.publish.calls[2][1].ok === true);
-    assert(context.publish.calls[2][1].error === null);
+    assert(context.publish.calls.length === 4);
+    assert(context.publish.calls[0][0] === 'x-test-suite-initialize'); // From initialization (sync).
+    assert(context.publish.calls[1][0] === 'x-test-suite-ready'); // From initialization (async).
+    assert(context.publish.calls[2][0] === 'x-test-root-run'); // This is from our test.
+    assert(context.publish.calls[3][0] === 'x-test-suite-result');
+    assert(context.publish.calls[3][1].itId === 'testItId');
+    assert(context.publish.calls[3][1].ok === true);
+    assert(context.publish.calls[3][1].error === null);
   });
 
   it('runs a test when told, not ok', async () => {
@@ -152,13 +156,14 @@ describe('initialize', () => {
     context.publish('x-test-root-run', { itId: 'testItId' });
     assert(called === true);
     await new Promise(resolve => setTimeout(resolve));
-    assert(context.publish.calls.length === 3);
-    assert(context.publish.calls[0][0] === 'x-test-suite-ready'); // This is from initialization.
-    assert(context.publish.calls[1][0] === 'x-test-root-run'); // This is from our test.
-    assert(context.publish.calls[2][0] === 'x-test-suite-result');
-    assert(context.publish.calls[2][1].itId === 'testItId');
-    assert(context.publish.calls[2][1].ok === false);
-    assert(context.publish.calls[2][1].error.message === 'test failure');
+    assert(context.publish.calls.length === 4);
+    assert(context.publish.calls[0][0] === 'x-test-suite-initialize'); // From initialization (sync).
+    assert(context.publish.calls[1][0] === 'x-test-suite-ready'); // From initialization (async).
+    assert(context.publish.calls[2][0] === 'x-test-root-run'); // This is from our test.
+    assert(context.publish.calls[3][0] === 'x-test-suite-result');
+    assert(context.publish.calls[3][1].itId === 'testItId');
+    assert(context.publish.calls[3][1].ok === false);
+    assert(context.publish.calls[3][1].error.message === 'test failure');
   });
 
   it('runs a test when told, todo, ok', async () => {
@@ -171,13 +176,14 @@ describe('initialize', () => {
     context.publish('x-test-root-run', { itId: 'testItId', directive: 'TODO' });
     assert(called === true);
     await new Promise(resolve => setTimeout(resolve));
-    assert(context.publish.calls.length === 3);
-    assert(context.publish.calls[0][0] === 'x-test-suite-ready'); // This is from initialization.
-    assert(context.publish.calls[1][0] === 'x-test-root-run'); // This is from our test.
-    assert(context.publish.calls[2][0] === 'x-test-suite-result');
-    assert(context.publish.calls[2][1].itId === 'testItId');
-    assert(context.publish.calls[2][1].ok === true);
-    assert(context.publish.calls[2][1].error === null);
+    assert(context.publish.calls.length === 4);
+    assert(context.publish.calls[0][0] === 'x-test-suite-initialize'); // From initialization (sync).
+    assert(context.publish.calls[1][0] === 'x-test-suite-ready'); // From initialization (async).
+    assert(context.publish.calls[2][0] === 'x-test-root-run'); // This is from our test.
+    assert(context.publish.calls[3][0] === 'x-test-suite-result');
+    assert(context.publish.calls[3][1].itId === 'testItId');
+    assert(context.publish.calls[3][1].ok === true);
+    assert(context.publish.calls[3][1].error === null);
   });
 
   it('runs a test when told, todo, not ok', async () => {
@@ -193,25 +199,27 @@ describe('initialize', () => {
     context.publish('x-test-root-run', { itId: 'testItId', directive: 'TODO' });
     assert(called === true);
     await new Promise(resolve => setTimeout(resolve));
-    assert(context.publish.calls.length === 3);
-    assert(context.publish.calls[0][0] === 'x-test-suite-ready'); // This is from initialization.
-    assert(context.publish.calls[1][0] === 'x-test-root-run'); // This is from our test.
-    assert(context.publish.calls[2][0] === 'x-test-suite-result');
-    assert(context.publish.calls[2][1].itId === 'testItId');
-    assert(context.publish.calls[2][1].ok === false);
-    assert(context.publish.calls[2][1].error.message === 'test failure');
+    assert(context.publish.calls.length === 4);
+    assert(context.publish.calls[0][0] === 'x-test-suite-initialize'); // From initialization (sync).
+    assert(context.publish.calls[1][0] === 'x-test-suite-ready'); // From initialization (async).
+    assert(context.publish.calls[2][0] === 'x-test-root-run'); // This is from our test.
+    assert(context.publish.calls[3][0] === 'x-test-suite-result');
+    assert(context.publish.calls[3][1].itId === 'testItId');
+    assert(context.publish.calls[3][1].ok === false);
+    assert(context.publish.calls[3][1].error.message === 'test failure');
   });
 
   it('closes registration after it is ready', async () => {
     const { context } = getContext();
     XTestSuite.initialize(context, '123', 'http://localhost:8080');
     await Promise.all(context.state.promises);
-    assert(context.publish.calls.length === 1);
-    assert(context.publish.calls[0][0] === 'x-test-suite-ready');
+    assert(context.publish.calls.length === 2);
+    assert(context.publish.calls[0][0] === 'x-test-suite-initialize');
+    assert(context.publish.calls[1][0] === 'x-test-suite-ready');
     XTestSuite.test(context, './test.html');
     XTestSuite.describe(context, 'nope', () => {});
     XTestSuite.it(context, 'nope', () => {});
-    assert(context.publish.calls.length === 1); // doesn't get registered.
+    assert(context.publish.calls.length === 2); // doesn't get registered.
   });
 });
 

--- a/types/x-test-common.d.ts
+++ b/types/x-test-common.d.ts
@@ -1,14 +1,28 @@
 export class XTestCommon {
     static TIMEOUT: symbol;
+    static IFRAME_ERROR: symbol;
+    static IFRAME_LOAD: symbol;
     /**
      * @param {number} interval - The timeout duration in milliseconds.
      * @returns {Promise<symbol>} Resolves to XTestCommon.TIMEOUT after interval.
      */
     static timeout(interval: number): Promise<symbol>;
     /**
-     * Promise that resolves at DOMContentLoaded.
-     * @param {Document} doc - Takes a parameter so tests can swap in a mock.
-     * @returns {Promise<void>}
+     * @param {EventTarget} iframe - The iframe element we are booting.
+     * @returns {Promise<symbol>} Resolves with XTestCommon.IFRAME_ERROR when
+     *   the iframe fires an error event (network-level failures).
      */
+    static iframeError(iframe: EventTarget): Promise<symbol>;
+    /**
+     * @param {EventTarget} iframe - The iframe element we are booting.
+     * @returns {Promise<symbol>} Resolves with XTestCommon.IFRAME_LOAD when
+     *   the iframe fires a load event.
+     */
+    static iframeLoad(iframe: EventTarget): Promise<symbol>;
+    /**
+    * Promise that resolves at DOMContentLoaded.
+    * @param {Document} doc - Takes a parameter so tests can swap in a mock.
+    * @returns {Promise<void>}
+    */
     static domContentLoadedPromise(doc: Document): Promise<void>;
 }

--- a/x-test-common.js
+++ b/x-test-common.js
@@ -1,5 +1,7 @@
 export class XTestCommon {
   static TIMEOUT = Symbol('timeout');
+  static IFRAME_ERROR = Symbol('iframeError');
+  static IFRAME_LOAD = Symbol('iframeLoad');
 
   /**
    * @param {number} interval - The timeout duration in milliseconds.
@@ -12,6 +14,28 @@ export class XTestCommon {
   }
 
   /**
+   * @param {EventTarget} iframe - The iframe element we are booting.
+   * @returns {Promise<symbol>} Resolves with XTestCommon.IFRAME_ERROR when
+   *   the iframe fires an error event (network-level failures).
+   */
+  static async iframeError(iframe) {
+    return await new Promise(resolve => {
+      iframe.addEventListener('error', () => { resolve(XTestCommon.IFRAME_ERROR); });
+    });
+  }
+
+  /**
+   * @param {EventTarget} iframe - The iframe element we are booting.
+   * @returns {Promise<symbol>} Resolves with XTestCommon.IFRAME_LOAD when
+   *   the iframe fires a load event.
+   */
+  static async iframeLoad(iframe) {
+    return await new Promise(resolve => {
+      iframe.addEventListener('load', () => { resolve(XTestCommon.IFRAME_LOAD); });
+    });
+  }
+
+   /**
    * Promise that resolves at DOMContentLoaded.
    * @param {Document} doc - Takes a parameter so tests can swap in a mock.
    * @returns {Promise<void>}

--- a/x-test-root.js
+++ b/x-test-root.js
@@ -1,4 +1,5 @@
 import { XTestReporter } from './x-test-reporter.js';
+import { XTestCommon } from './x-test-common.js';
 import { XTestTap } from './x-test-tap.js';
 
 export class XTestRoot {
@@ -35,8 +36,14 @@ export class XTestRoot {
         case 'x-test-client-coverage-result':
           XTestRoot.onCoverageResult(context, event);
           break;
+        case 'x-test-root-defer':
+          XTestRoot.onDefer(context, event);
+          break;
         case 'x-test-suite-register':
           XTestRoot.onRegister(context, event);
+          break;
+        case 'x-test-suite-initialize':
+          XTestRoot.onInitialize(context, event);
           break;
         case 'x-test-suite-ready':
           XTestRoot.onReady(context, event);
@@ -71,6 +78,48 @@ export class XTestRoot {
   static onBail(context, event) {
     if (!context.state.ended) {
       XTestRoot.bail(context, event.data.data.error, { testId: event.data.data.testId });
+    }
+  }
+
+  /**
+   * @param {any} context
+   * @param {any} event
+   */
+  static onInitialize(context, event) {
+    if (!context.state.ended) {
+      const testId = event.data.data.testId;
+      const test = context.state.tests[testId];
+      test.initialized = true;
+    }
+  }
+
+  /**
+   * @param {any} context
+   * @param {any} event
+   */
+  static onDefer(context, event) {
+    if (!context.state.ended) {
+      const data = event.data.data;
+      switch (data.type) {
+        case 'check-initialized':
+          XTestRoot.checkInitialized(context, data);
+          break;
+        default:
+          throw new Error(`Unexpected defer type "${data.type}".`);
+      }
+    }
+  }
+
+  /**
+   * @param {any} context
+   * @param {any} data
+   */
+  static checkInitialized(context, data) {
+    if (!context.state.ended) {
+      const test = context.state.tests[data.testId];
+      if (!test.initialized) {
+        XTestRoot.bail(context, new Error(`Failed to initialize ${data.href}`));
+      }
     }
   }
 
@@ -475,10 +524,29 @@ export class XTestRoot {
     const step = context.state.steps[stepId];
     const href = XTestRoot.href(context, stepId);
     const iframe = document.createElement('iframe');
-    iframe.addEventListener('error', () => {
-      const error = new Error(`Failed to load ${href}`);
-      XTestRoot.bail(context, error);
+    const timeout = context.timeout(30_000);
+    const iframeError = context.iframeError(iframe);
+    const iframeLoad = context.iframeLoad(iframe);
+
+    Promise.race([timeout, iframeError, iframeLoad]).then(result => {
+      if (!context.state.ended) {
+        switch (result) {
+          case XTestCommon.TIMEOUT:
+            XTestRoot.bail(context, new Error(`Timed out loading ${href}`));
+            break;
+          case XTestCommon.IFRAME_ERROR:
+            XTestRoot.bail(context, new Error(`Failed to load ${href}`));
+            break;
+          case XTestCommon.IFRAME_LOAD:
+            // To ensure the child frame is given adequate time to register
+            //  after being loaded, we wait for a message in the queue to be
+            //  processed before giving up. See handler for more detail.
+            context.publish('x-test-root-defer', { type: 'check-initialized', testId: step.testId, href });
+            break;
+        }
+      }
     });
+
     iframe.setAttribute('data-x-test-test-id', step.testId);
     Object.assign(iframe, { src: href });
     Object.assign(iframe.style, {

--- a/x-test-suite.js
+++ b/x-test-suite.js
@@ -8,6 +8,7 @@ export class XTestSuite {
    */
   static initialize(context, testId, href) {
     Object.assign(context.state, { testId, href });
+    context.publish('x-test-suite-initialize', { testId });
     context.state.parents.push({ type: 'test', testId });
     context.subscribe(async (/** @type {any} */ event) => {
       switch (event.data.type) {

--- a/x-test.js
+++ b/x-test.js
@@ -171,7 +171,10 @@ if (!frameElement?.getAttribute('data-x-test-test-id')) {
     coverageValue: null, reporter: null, filtering: false, queue: [],
     queueing: false,
   };
-  const rootContext = { state, uuid, publish, subscribe, timeout: XTestCommon.timeout };
+  const rootContext = {
+    state, uuid, publish, subscribe, timeout: XTestCommon.timeout,
+    iframeError: XTestCommon.iframeError, iframeLoad: XTestCommon.iframeLoad,
+  };
   XTestRoot.initialize(rootContext, location.href);
 } else {
   const state = {


### PR DESCRIPTION
Fixes the handling and logging for the failures modes when loading an iframe element for a sub-test:

```js
test('./does-not-exist.html');           // 404 → 1..0 ok
test('./some/spa/route');                // 200, wrong content → 1..0 ok
test('http://127.0.0.1:9999/test.html'); // unreachable → hang
```

Closes #82.