### PR TITLE
Fixes issue with root iframe load event timing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Suites no longer bail with “Timed out loading …” partway through an
+  otherwise successful run. When the child’s `ready` beat its iframe
+  load event, the iframe was removed before load could dispatch and
+  the load-phase timer later settled a stale race (#83).
 - Iframes pointed at bad URLs (404, 500, SPA fallbacks, unreachable
   hosts) now fail cleanly with a clear error instead of silently
   passing as `1..0 ok` or hanging (#82).

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,6 +19,7 @@
         <li><a href="./todo">demo for todo</a></li>
         <li><a href="./nest">demo for nesting tests</a></li>
         <li><a href="./debug">demo for debugging in the browser</a></li>
+        <li><a href="./stale-race">demo for stale-race guard (35s long)</a></li>
         <li><a href="../test">run actual tests</a></li>
       </ul>
     </div>

--- a/demo/stale-race/index.html
+++ b/demo/stale-race/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
+  <body>
+    <h3>demo stale-race guard</h3>
+    <!--
+      Open in a real browser (not Puppeteer). This root has no tests of
+      its own — it only registers a slow sibling test. The sequence:
+        1. Root boots, creates self-iframe for this same URL.
+        2. Self-iframe loads (cached), publishes `ready`, registers the
+           sibling, and reports completion before its own iframe.load
+           dispatches on the parent.
+        3. Parent kicks off the sibling, which removes the self-iframe.
+           Its pending load event is now discarded.
+        4. ~30s later the self-iframe's load-phase timer fires. Without
+           the stale-race guard the run bails with "Timed out loading".
+           With the guard, the stale timer is ignored and the demo
+           completes cleanly ~35s in.
+    -->
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/demo/stale-race/index.js
+++ b/demo/stale-race/index.js
@@ -1,0 +1,3 @@
+import { test } from '../../x-test.js';
+
+test('./keepalive.html');

--- a/demo/stale-race/keepalive.html
+++ b/demo/stale-race/keepalive.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
+  </head>
+  <body>
+    <h3>demo stale-race keepalive</h3>
+    <script type="module" src="./keepalive.js"></script>
+  </body>
+</html>

--- a/demo/stale-race/keepalive.js
+++ b/demo/stale-race/keepalive.js
@@ -1,0 +1,6 @@
+import { assert, it } from '../../x-test.js';
+
+it('runs past the 30s load-phase timer', async () => {
+  await new Promise(resolve => { setTimeout(resolve, 35_000); });
+  assert(true);
+}, 60_000);

--- a/x-test-root.js
+++ b/x-test-root.js
@@ -361,6 +361,12 @@ export class XTestRoot {
   static onReady(context, event) {
     if (!context.state.ended) {
       const data = event.data.data;
+      // Ready means this iframe’s x-test is up — the load-phase race is moot.
+      //  Flag the test so a late timeout / error / load doesn’t bail.
+      const readyTest = context.state.tests[data.testId];
+      if (readyTest) {
+        readyTest.ready = true;
+      }
       const only = (
         Object.values(context.state.its).some((/** @type {any} */ candidate) => {
           return candidate.only && candidate.parents[0].testId === data.testId;
@@ -529,7 +535,11 @@ export class XTestRoot {
     const iframeLoad = context.iframeLoad(iframe);
 
     Promise.race([timeout, iframeError, iframeLoad]).then(result => {
-      if (!context.state.ended) {
+      // Ready may have arrived before the iframe’s load/error event, in
+      //  which case the iframe has already been removed and this race is
+      //  stale — the pending timeout would otherwise fire ~30s later.
+      //  Comment “ready” condition and load /demo/stale-race to reproduce.
+      if (!context.state.ended && !context.state.tests[step.testId]?.ready) {
         switch (result) {
           case XTestCommon.TIMEOUT:
             XTestRoot.bail(context, new Error(`Timed out loading ${href}`));


### PR DESCRIPTION
The crux of this issue is fixing mis-reporting for some edge cases that commonly happen when running tests.

The symptom is that the reporter can mis-diagnose the issue as a problem with the root test (thinking that the root test timed out), when the actual failure (or simply slow test) is in a child sub-test iframe.

The fix it to catch the edge case where the timeout fires on the root, but we can detect that the tests _did_ actually run.

Closes #83.