### PR TITLE
Fix “TAP Version 14” > “TAP version 14” text.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TAP version pragma now emits `TAP version 14` (lower-case `v`) to
+  match the TAP specification text (#88).
 - Suites no longer bail with “Timed out loading …” partway through an
   otherwise successful run. When the child’s `ready` beat its iframe
   load event, the iframe was removed before load could dispatch and

--- a/test/test-reporter.js
+++ b/test/test-reporter.js
@@ -4,7 +4,7 @@ import { XTestReporter } from '../x-test-reporter.js';
 describe('render', () => {
   it('prints out basic test', () => {
     const tap = [
-      'TAP Version 14',
+      'TAP version 14',
       '# Subtest: http://127.0.0.1:8080/test/',
       '    # Subtest: level 1',
       '        ok 1 - first test',
@@ -37,7 +37,7 @@ describe('render', () => {
 
   it('bails', () => {
     const tap = [
-      'TAP Version 14',
+      'TAP version 14',
       '# Subtest: http://127.0.0.1:8080/test/',
       '    # these',
       '    # are',

--- a/test/test-tap.js
+++ b/test/test-tap.js
@@ -2,8 +2,8 @@ import { it, describe, assert } from '../x-test.js';
 import { XTestTap } from '../x-test-tap.js';
 
 describe('version', () => {
-  it('renders "TAP Version 14"', () => {
-    assert(XTestTap.version() === 'TAP Version 14');
+  it('renders "TAP version 14"', () => {
+    assert(XTestTap.version() === 'TAP version 14');
   });
 });
 

--- a/x-test-tap.js
+++ b/x-test-tap.js
@@ -12,7 +12,7 @@ export class XTestTap {
    * @returns {string}
    */
   static version() {
-    return 'TAP Version 14';
+    return 'TAP version 14';
   }
 
   /**


### PR DESCRIPTION
Simple change to make the “V” lowercase. See TAP 14 specification:

https://testanything.org/tap-version-14-specification.html

Closes #88.