### PR TITLE
Re-iterate test failures after normal exit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Summarize errors encountered during the test run as diagnostics under a
+  `# Failures:` header. This allows both humans and machines to “tail” the
+  output (versus having to understand the entire output at all times) (#89).
+
 ### Fixed
 
 - TAP version pragma now emits `TAP version 14` (lower-case `v`) to

--- a/test/test-reporter.js
+++ b/test/test-reporter.js
@@ -56,7 +56,7 @@ describe('render', () => {
 describe('parse', () => {
   it('parses test', () => {
     const output = '# Subtest: http://example.com/test.html';
-    const result = XTestReporter.parse(output);
+    const result = XTestReporter.parse(output, false);
     assert(result.tag === 'a');
     assert(Object.keys(result.properties).length === 2);
     assert(result.properties.href === 'http://example.com/test.html');
@@ -70,7 +70,7 @@ describe('parse', () => {
 
   it('parses bail test', () => {
     const output = 'Bail out! http://example.com/test.html';
-    const result = XTestReporter.parse(output);
+    const result = XTestReporter.parse(output, false);
     assert(result.tag === 'a');
     assert(Object.keys(result.properties).length === 2);
     assert(result.properties.href === 'http://example.com/test.html');
@@ -85,7 +85,7 @@ describe('parse', () => {
 
   it('parses diagnostic', () => {
     const output = '# something, anything';
-    const result = XTestReporter.parse(output);
+    const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
     assert(Object.keys(result.properties).length === 1);
     assert(result.properties.innerText === output);
@@ -98,7 +98,7 @@ describe('parse', () => {
 
   it('parses test line', () => {
     const output = 'ok 145 - this cool thing i tested';
-    const result = XTestReporter.parse(output);
+    const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
     assert(Object.keys(result.properties).length === 1);
     assert(result.properties.innerText === output);
@@ -112,7 +112,7 @@ describe('parse', () => {
 
   it('parses "SKIP" test line', () => {
     const output = 'ok 145 - this cool thing i tested # SKIP';
-    const result = XTestReporter.parse(output);
+    const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
     assert(Object.keys(result.properties).length === 1);
     assert(result.properties.innerText === output);
@@ -127,7 +127,7 @@ describe('parse', () => {
 
   it('parses "TODO" test line', () => {
     const output = 'ok 145 - this cool thing i tested # TODO';
-    const result = XTestReporter.parse(output);
+    const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
     assert(Object.keys(result.properties).length === 1);
     assert(result.properties.innerText === output);
@@ -142,7 +142,7 @@ describe('parse', () => {
 
   it('parses "not ok" test line', () => {
     const output = 'not ok 145 - this cool thing i tested';
-    const result = XTestReporter.parse(output);
+    const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
     assert(Object.keys(result.properties).length === 1);
     assert(result.properties.innerText === output);
@@ -155,7 +155,7 @@ describe('parse', () => {
 
   it('parses "not ok", "TODO" test line', () => {
     const output = 'not ok 145 - this cool thing i tested # TODO tbd...';
-    const result = XTestReporter.parse(output);
+    const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
     assert(Object.keys(result.properties).length === 1);
     assert(result.properties.innerText === output);
@@ -169,7 +169,7 @@ describe('parse', () => {
 
   it('parses version', () => {
     const output = 'TAP version 14';
-    const result = XTestReporter.parse(output);
+    const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
     assert(Object.keys(result.properties).length === 1);
     assert(result.properties.innerText === output);
@@ -178,5 +178,40 @@ describe('parse', () => {
     assert(result.attributes.version === '');
     assert(result.done === false);
     assert(result.failed === false);
+  });
+
+  it('parses in-failures bare URL as link', () => {
+    const output = '# http://example.com/test.html';
+    const result = XTestReporter.parse(output, true);
+    assert(result.tag === 'a');
+    assert(result.properties.href === 'http://example.com/test.html');
+    assert(result.attributes.failure === '');
+  });
+
+  it('parses in-failures breadcrumb segment as failure', () => {
+    const output = '# > this test failed';
+    const result = XTestReporter.parse(output, true);
+    assert(result.tag === 'div');
+    assert(result.attributes.failure === '');
+  });
+
+  it('parses in-failures yaml body as failure', () => {
+    const output = '#     Error: nope';
+    const result = XTestReporter.parse(output, true);
+    assert(result.attributes.failure === '');
+  });
+
+  it('tags in-failures blank separator as failure', () => {
+    const output = '# ';
+    const result = XTestReporter.parse(output, true);
+    assert(result.attributes.failure === '');
+  });
+
+  it('leaves pre-failures diagnostics untouched', () => {
+    const output = '# http://example.com/test.html';
+    const result = XTestReporter.parse(output, false);
+    assert(result.attributes.failure === undefined);
+    assert(result.attributes.diagnostic === '');
+    assert(result.tag === 'div');
   });
 });

--- a/test/test-root.js
+++ b/test/test-root.js
@@ -205,3 +205,92 @@ const expectedOutput = `\
     assert(analysis.percent === 72);
   });
 });
+
+describe('collectFailureStepIds', () => {
+  it('returns failing it step ids in order, excluding TODO and passing', () => {
+    const { context } = getContext();
+    context.state.stepIds.push('s1', 's2', 's3', 's4');
+    context.state.steps = {
+      s1: { type: 'it', itId: 'passIt' },
+      s2: { type: 'it', itId: 'failIt' },
+      s3: { type: 'it', itId: 'todoIt' },
+      s4: { type: 'version' },
+    };
+    context.state.its = {
+      passIt: { ok: true },
+      failIt: { ok: false },
+      todoIt: { ok: false, directive: 'TODO' },
+    };
+    const ids = XTestRoot.collectFailureStepIds(context);
+    assert(ids.length === 1);
+    assert(ids[0] === 's2');
+  });
+
+  it('does not include failing coverage steps', () => {
+    const { context } = getContext();
+    context.state.stepIds.push('s1');
+    context.state.steps = { s1: { type: 'coverage', coverageId: 'c1' } };
+    context.state.coverages = { c1: { ok: false } };
+    const ids = XTestRoot.collectFailureStepIds(context);
+    assert(ids.length === 0);
+  });
+});
+
+describe('formatFailure', () => {
+  it('formats a failing "it" with arrow-joined breadcrumb and raw stack', () => {
+    const { context } = getContext();
+    context.state.stepIds.push('s1');
+    context.state.steps['s1'] = { stepId: 's1', type: 'it', itId: 'i1' };
+    context.state.tests['t1'] = { href: 'http://example.com/test.html', children: [{ type: 'describe', describeId: 'd1' }] };
+    context.state.describes['d1'] = {
+      text: 'outer',
+      parents: [{ type: 'test', testId: 't1' }],
+      children: [{ type: 'it', itId: 'i1' }],
+    };
+    context.state.its['i1'] = {
+      itId: 'i1',
+      text: 'does the thing',
+      ok: false,
+      directive: null,
+      error: { message: 'nope', stack: 'Error: nope\n    at foo' },
+      parents: [{ type: 'test', testId: 't1' }, { type: 'describe', describeId: 'd1' }],
+    };
+    const block = XTestRoot.formatFailure(context, 's1');
+    const lines = block.split('\n');
+    assert(lines[0] === 'http://example.com/test.html');
+    assert(lines[1] === '> outer');
+    assert(lines[2] === '> does the thing');
+    assert(lines[3] === 'Error: nope');
+    assert(lines[4] === '    at foo');
+  });
+
+  it('falls back to "Error: <message>" when stack is missing', () => {
+    const { context } = getContext();
+    context.state.stepIds.push('s1');
+    context.state.steps['s1'] = { stepId: 's1', type: 'it', itId: 'i1' };
+    context.state.tests['t1'] = { href: 'http://example.com/test.html', children: [] };
+    context.state.its['i1'] = {
+      itId: 'i1',
+      text: 'the test',
+      ok: false,
+      directive: null,
+      error: { message: 'nope' },
+      parents: [{ type: 'test', testId: 't1' }],
+    };
+    const block = XTestRoot.formatFailure(context, 's1');
+    const lines = block.split('\n');
+    assert(lines[lines.length - 1] === 'Error: nope');
+  });
+
+});
+
+describe('check', () => {
+  it('does not kick off the exit step once the run has ended (e.g. after a bail)', () => {
+    const { context } = getContext();
+    context.state.stepIds.push('exitStep');
+    context.state.steps = { exitStep: { type: 'exit', status: 'waiting' } };
+    context.state.ended = true;
+    XTestRoot.check(context);
+    assert(context.state.steps.exitStep.status === 'waiting');
+  });
+});

--- a/x-test-reporter.css.js
+++ b/x-test-reporter.css.js
@@ -202,6 +202,15 @@ a[subtest]:not([bail]) {
   color: var(--subdued);
 }
 
+[failure] {
+  color: var(--not-ok);
+}
+
+a[failure]:any-link {
+  color: var(--not-ok);
+  text-decoration: underline;
+}
+
 [indent] {
   position: relative;
 }

--- a/x-test-reporter.js
+++ b/x-test-reporter.js
@@ -21,6 +21,10 @@ export class XTestReporter extends HTMLElement {
   #root;
   /** @type {References} */
   #references;
+  /** @type {boolean} */
+  #postRun = false;
+  /** @type {boolean} */
+  #inFailures = false;
 
   /**
    * @template {keyof HTMLElementTagNameMap | keyof SVGElementTagNameMap} T
@@ -130,7 +134,10 @@ export class XTestReporter extends HTMLElement {
   tap(...tap) {
     const items = [];
     for (const text of tap) {
-      const { tag, properties, attributes, failed, done } = XTestReporter.parse(text);
+      if (this.#postRun && text === '# Failures:') {
+        this.#inFailures = true;
+      }
+      const { tag, properties, attributes, failed, done } = XTestReporter.parse(text, this.#inFailures);
       const element = document.createElement(tag);
       Object.assign(element, properties);
       for (const [attribute, value] of Object.entries(attributes)) {
@@ -138,6 +145,7 @@ export class XTestReporter extends HTMLElement {
       }
       if (done) {
         this.removeAttribute('testing');
+        this.#postRun = true;
       }
       if (failed) {
         this.removeAttribute('ok');
@@ -149,9 +157,10 @@ export class XTestReporter extends HTMLElement {
 
   /**
    * @param {string} text
+   * @param {boolean} inFailures
    * @returns {{tag: string, properties: Record<string, any>, attributes: Record<string, any>, failed: boolean, done: boolean}}
    */
-  static parse(text) {
+  static parse(text, inFailures) {
     const result = { tag: '', properties: /** @type {Record<string, any>} */ ({}), attributes: /** @type {Record<string, any>} */ ({}), failed: false, done: false };
     result.properties.innerText = text;
     const indentMatch = text.match(/^((?: {4})+)/);
@@ -204,6 +213,14 @@ export class XTestReporter extends HTMLElement {
       } else if (text.match(/^(?: {4})*Bail out!.*/)) {
         result.attributes.bail = '';
         result.failed = true;
+      }
+    }
+    if (inFailures && 'diagnostic' in result.attributes) {
+      result.attributes.failure = '';
+      const urlMatch = text.match(/^# (https?:\/\/\S+)$/);
+      if (urlMatch) {
+        result.tag = 'a';
+        result.properties.href = urlMatch[1];
       }
     }
     return result;

--- a/x-test-root.js
+++ b/x-test-root.js
@@ -644,10 +644,64 @@ export class XTestRoot {
    */
   static kickoffExit(context, stepId) {
     const count = XTestRoot.count(context, stepId);
-    const tap = XTestTap.plan(count);
-    XTestRoot.output(context, stepId, tap);
+    const planTap = XTestTap.plan(count);
+    const failureTap = [];
+    const failureStepIds = XTestRoot.collectFailureStepIds(context);
+    if (failureStepIds.length > 0) {
+      failureTap.push(XTestTap.diagnostic('Failures:'));
+      for (const failureStepId of failureStepIds) {
+        failureTap.push(XTestTap.diagnostic(''));
+        for (const line of XTestRoot.formatFailure(context, failureStepId).split('\n')) {
+          failureTap.push(XTestTap.diagnostic(line));
+        }
+      }
+    }
+    XTestRoot.output(context, stepId, planTap, ...failureTap);
     context.state.steps[stepId].status = 'done';
     XTestRoot.end(context);
+  }
+
+  /**
+   * @param {any} context
+   * @returns {string[]}
+   */
+  static collectFailureStepIds(context) {
+    const failureStepIds = [];
+    for (const stepId of context.state.stepIds) {
+      const step = context.state.steps[stepId];
+      if (step.type === 'it') {
+        const it = context.state.its[step.itId];
+        if (it.ok === false && it.directive !== 'TODO') {
+          failureStepIds.push(stepId);
+        }
+      }
+    }
+    return failureStepIds;
+  }
+
+  /**
+   * @param {any} context
+   * @param {any} stepId
+   * @returns {string}
+   */
+  static formatFailure(context, stepId) {
+    const step = context.state.steps[stepId];
+    const it = context.state.its[step.itId];
+    const test = context.state.tests[it.parents[0].testId];
+    const lines = [test.href];
+    const describeParents = it.parents.filter((/** @type {any} */ parent) => parent.type === 'describe');
+    for (const parent of describeParents) {
+      lines.push(`> ${context.state.describes[parent.describeId].text.replace(/#/g, '*')}`);
+    }
+    lines.push(`> ${it.text.replace(/#/g, '*')}`);
+    if (it.error.stack) {
+      for (const stackLine of it.error.stack.split('\n')) {
+        lines.push(stackLine);
+      }
+    } else {
+      lines.push(`Error: ${it.error.message}`);
+    }
+    return lines.join('\n');
   }
 
   /**


### PR DESCRIPTION
In order to make it easier for humans (and AI assistants) to “tail” test output, we need to re-iterate the failures. This way, we have the real TAP output (unchanged) followed by an easily-digestible tail which can be quickly iterated upon (without having to go searching / scrolling for failures).

Closes #89.

<img width="1208" height="1314" alt="Screenshot 2026-04-20 at 8 09 15 PM" src="https://github.com/user-attachments/assets/7578d9ae-ff3a-4455-b2d1-d6bd93762ed0" />
