### PR TITLE
Migrate to new CLI interface.

### DIFF
--- a/.github/workflows/publish-to-jsr.yaml
+++ b/.github/workflows/publish-to-jsr.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.18'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       # Can we get this to use “deno publish”?

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.18'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
       - run: npm publish
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.18'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules
+coverage
 types/x-test-reporter.css.d.ts
 types/x-test-reporter.d.ts
 types/x-test-root.d.ts
 types/x-test-suite.d.ts
 types/x-test-tap.d.ts
+types/x-test.config.d.ts
+types/x-test-common.d.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `x-test-name` URL parameter has been renamed to `x-test-name-pattern`
+  to more clearly signal that it accepts a regex pattern rather than a
+  literal name and matches Node’s test CLI argument naming (#99).
+
+### Removed
+
+- The `coverage()` API, the `x-test-run-coverage` URL
+  parameter, and all associated TAP output have been removed. Coverage
+  analysis is now the exclusive responsibility of `@netflix/x-test-cli` (#99).
+- The `x-test-no-reporter` URL parameter has been removed.
+  The reporter UI is now always rendered (#99).
+- The public `BroadcastChannel` events `x-test-client-ping`,
+  `x-test-root-pong`, `x-test-root-coverage-request`,
+  `x-test-client-coverage-result`, and `x-test-root-end` have been removed.
+  The CLI now observes a run solely by consuming TAP output from the
+  console (#99).
+
 ## [2.0.0-rc.7] - 2026-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ a simple, tap-compliant test runner for the browser
 - nested sub-tests run in an iframe
 - has a recognizable testing interface (`it`, `describe`, `assert`)
 - can be used for automated testing
-- can be used to assert coverage goals
 
 ## Interface
 
@@ -22,41 +21,18 @@ The following are exposed in the testing interface:
 - `it.skip`: An `it` whose callback is not run and which will pass.
 - `it.only`: Skip all other `it` tests.
 - `it.todo`: An `it` whose callback _is_ run and is expected to fail.
-- `describe`: Simple grouping functionality.
+- `describe`: Simple synchronous grouping functionality.
 - `describe.skip`: Skip all `it` tests in this group.
 - `describe.only`: Skip all other `describe` groups and `it` tests.
 - `describe.todo`: Mark all `it` tests within this group as _todo_.
 - `waitFor`: Ensures test registration remains open until given promise settles.
 - `assert`: Simple assertion call that throws if the boolean input is false-y.
-- `coverage`: Sets a coverage goal for the given href.
-
-### Events
-
-Messages are posted to a `BroadcastChannel` channel with the name `x-test`.
-
-- `x-test-client-ping`: root responds (`x-test-root-pong`, { status: 'started'|'ended' waiting: true|false })
-- `x-test-root-pong`: response to `x-test-client-ping`
-- `x-test-root-coverage-request`: client should respond (`x-test-coverage-result`)
-- `x-test-client-coverage-result`: response to `x-test-root-coverage-request`
-- `x-test-root-end`: all tests have completed or we bailed out
-- (internal) `x-test-root-run`: all tests have completed or we bailed out
-- (internal) `x-test-root-defer`: defer work until round-trip through BroadcastChannel queue
-- (internal) `x-test-suite-initialize`: published the moment suite it boots for tracking load success
-- (internal) `x-test-suite-coverage`: signal to test for coverage on a particular file
-- (internal) `x-test-suite-register`: registers a new test / describe / it
-- (internal) `x-test-suite-ready`: signal that test suite is done with registration
-- (internal) `x-test-suite-result`: marks end of "it" test
-- (internal) `x-test-suite-bail`: signal to quit test early
 
 ### Parameters
 
 The following parameters can be passed in via query params on the url:
 
-- `x-test-no-reporter`: turns off custom reporting tool ui
-- `x-test-run-coverage`: turns on coverage reporting**
-- `x-test-name`: filters tests by name using regex pattern matching
-
-**See [Command Line Usage](#command-line-usage).
+- `x-test-name-pattern`: filters tests by name using regex pattern matching
 
 ## Execution
 
@@ -68,11 +44,11 @@ given html page in an iframe. Such iframes are run one-at-a-time. All invoked
 
 ## Test Filtering
 
-You can filter tests by name using the `x-test-name` query parameter, which accepts a regex pattern. This allows you to run only specific tests that match the pattern.
+You can filter tests by name using the `x-test-name-pattern` query parameter, which accepts a regex pattern. This allows you to run only specific tests that match the pattern.
 
 ### Browser Usage
 ```
-http://localhost:8080/test/?x-test-name=should%20validate
+http://localhost:8080/test/?x-test-name-pattern=should%20validate
 ```
 
 ### Command Line Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@netflix/eslint-config": "3.0.0",
-        "@netflix/x-test-cli": "1.0.0-rc.2",
+        "@netflix/x-test-cli": "1.0.0-rc.5",
         "eslint": "10.1.0",
         "eslint-plugin-jsdoc": "62.8.0",
         "globals": "17.4.0",
         "typescript": "6.0.2"
       },
       "engines": {
-        "node": ">=20.18",
+        "node": ">=22",
         "npm": ">=10.8"
       }
     },
@@ -77,6 +77,8 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
       "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
@@ -90,6 +92,8 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -102,6 +106,8 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -116,6 +122,8 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -124,13 +132,17 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -140,6 +152,8 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -149,6 +163,8 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -161,6 +177,8 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
       "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -170,6 +188,8 @@
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
       "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
@@ -184,6 +204,8 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -196,6 +218,8 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -210,6 +234,8 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -218,13 +244,17 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -234,6 +264,8 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -243,6 +275,8 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -469,22 +503,43 @@
         "@eslint/js": "^8.21.0"
       }
     },
-    "node_modules/@netflix/x-test-cli": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@netflix/x-test-cli/-/x-test-cli-1.0.0-rc.2.tgz",
-      "integrity": "sha512-NFK/CGtLYpqH5JEzkYR784gv0QUnXpiezKxBjYMSMixu/3k7rYdFKpx7mEuAGqUeuibSsyhqMfenYyUPIjCUKg==",
+    "node_modules/@netflix/x-test": {
+      "version": "2.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@netflix/x-test/-/x-test-2.0.0-rc.7.tgz",
+      "integrity": "sha512-EInFnR7lY7dloc/5haFlOhh0/iesWkysd3e/F+qUi9bjY/HjKHUuztCQAk0Jeb88TjbRks6BIbNKdRhDn850HA==",
       "dev": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "puppeteer": ">=20.0.0",
-        "tap-parser": ">=18.0.0"
-      },
+      "peer": true,
+      "engines": {
+        "node": ">=20.18",
+        "npm": ">=10.8"
+      }
+    },
+    "node_modules/@netflix/x-test-cli": {
+      "version": "1.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@netflix/x-test-cli/-/x-test-cli-1.0.0-rc.5.tgz",
+      "integrity": "sha512-pOf1sVYQwZBIRqtBh1WKIPI7P/CIVb3Pr6Xe1NFPIBB6PAdE69F1oIzqw1+M7tUwtBIdMzzvj52mQUCS8i5ZQA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "x-test": "x-test-cli.js"
       },
       "engines": {
-        "node": ">=20.18",
+        "node": ">=22",
         "npm": ">=10.8"
+      },
+      "peerDependencies": {
+        "@netflix/x-test": "^2.0.0-rc.6",
+        "playwright": ">=1.40.0",
+        "puppeteer": ">=20.0.0"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "puppeteer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -493,6 +548,8 @@
       "integrity": "sha512-MK7rtm8JjaxPN7Mf1JdZIZKPD2Z+W7osvrC1vjpvfOX1K0awDIHYbNi89f7eotp7eMUn2shWnt03HwVbriXtKQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "extract-zip": "^2.0.1",
@@ -527,12 +584,16 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/color-name": {
       "version": "1.1.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -562,6 +623,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -573,6 +635,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -620,6 +683,8 @@
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -647,6 +712,8 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -655,6 +722,8 @@
       "version": "4.2.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/color-name": "^1.1.1",
         "color-convert": "^2.0.1"
@@ -679,7 +748,9 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "dev": true,
-      "license": "Python-2.0"
+      "license": "Python-2.0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
@@ -687,6 +758,8 @@
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -699,7 +772,9 @@
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
       "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -717,7 +792,8 @@
       "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/bare-fs": {
       "version": "4.0.1",
@@ -726,6 +802,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bare-events": "^2.0.0",
         "bare-path": "^3.0.0",
@@ -742,6 +819,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "engines": {
         "bare": ">=1.6.0"
       }
@@ -753,6 +831,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
@@ -764,6 +843,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "streamx": "^2.21.0"
       },
@@ -786,6 +866,8 @@
       "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -809,6 +891,8 @@
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -818,6 +902,8 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -828,6 +914,8 @@
       "integrity": "sha512-G3x1bkST13kmbL7+dT/oRkNH/7C4UqG+0YQpmySrzXspyOhYgDNc6lhSGpj3cuexvH25WTENhTYq2Tt9JRXtbw==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mitt": "^3.0.1",
         "zod": "^3.24.1"
@@ -842,6 +930,8 @@
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -855,6 +945,8 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -865,7 +957,9 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/comment-parser": {
       "version": "1.4.5",
@@ -882,6 +976,8 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -924,6 +1020,8 @@
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -958,6 +1056,8 @@
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -972,14 +1072,18 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1402036.tgz",
       "integrity": "sha512-JwAYQgEvm3yD45CHB+RmF5kMbWtXBaOGwuxa87sZogHcLCv8c/IqnThaoQ1y60d7pXWjSKWQphPEc+1rAScVdg==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -987,6 +1091,8 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -996,6 +1102,8 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1005,6 +1113,8 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -1015,6 +1125,8 @@
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1036,6 +1148,8 @@
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -1193,6 +1307,8 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -1244,20 +1360,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/events-to-array": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -1285,7 +1395,9 @@
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -1306,6 +1418,8 @@
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -1365,6 +1479,8 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -1375,6 +1491,8 @@
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -1391,6 +1509,8 @@
       "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -1458,6 +1578,8 @@
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -1472,6 +1594,8 @@
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -1495,6 +1619,8 @@
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -1520,6 +1646,8 @@
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -1532,7 +1660,9 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1548,6 +1678,8 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1574,12 +1706,16 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1592,7 +1728,9 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "7.1.1",
@@ -1615,7 +1753,9 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -1656,7 +1796,9 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -1678,6 +1820,8 @@
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1703,7 +1847,9 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1723,6 +1869,8 @@
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -1740,6 +1888,8 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -1795,6 +1945,8 @@
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -1815,6 +1967,8 @@
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -1828,6 +1982,8 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -1850,6 +2006,8 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -1893,7 +2051,9 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -1910,6 +2070,8 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1920,6 +2082,8 @@
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -1939,7 +2103,9 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/pump": {
       "version": "3.0.2",
@@ -1947,6 +2113,8 @@
       "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -1969,6 +2137,8 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.7.1",
         "chromium-bidi": "1.3.0",
@@ -1990,6 +2160,8 @@
       "integrity": "sha512-bCypUh3WXzETafv1TCFAjIUnI8BiQ/d+XvEfEXDLcIMm9CAvROqnBmbt79yBjwasoDZsgfXnUmIJU7Y27AalVQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.7.1",
         "chromium-bidi": "1.3.0",
@@ -2008,6 +2180,8 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2030,6 +2204,8 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -2076,6 +2252,8 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -2087,6 +2265,8 @@
       "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -2102,6 +2282,8 @@
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -2118,6 +2300,7 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2152,7 +2335,9 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/streamx": {
       "version": "2.22.0",
@@ -2160,6 +2345,8 @@
       "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
@@ -2174,6 +2361,8 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2189,42 +2378,13 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/tap-parser": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-18.0.0.tgz",
-      "integrity": "sha512-RM3Lp5LNCYcepRqPMuDFg8S3uYV8MDmgxUOjx2Q7f2z5QuB88u92ViBwyp3MuQ/DVMR7v48HrJfV2scXRQYf5A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "events-to-array": "^2.0.3",
-        "tap-yaml": "4.0.0"
-      },
-      "bin": {
-        "tap-parser": "bin/cmd.cjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/tap-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-4.0.0.tgz",
-      "integrity": "sha512-CjMbq8hhT5TvzyvHRnzbGp00wmb4TZjSscCRCCJCdCzRb+Pb56HaMlBHNBn1/GZ6UqwUgDKdF18+9VAFnQ4F0g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "yaml": "^2.4.1",
-        "yaml-types": "^0.4.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/tar-fs": {
@@ -2233,6 +2393,8 @@
       "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -2248,6 +2410,8 @@
       "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -2260,6 +2424,8 @@
       "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "b4a": "^1.6.4"
       }
@@ -2286,7 +2452,9 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true,
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2305,7 +2473,9 @@
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/typescript": {
       "version": "6.0.2",
@@ -2327,7 +2497,8 @@
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -2361,6 +2532,8 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -2378,7 +2551,9 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ws": {
       "version": "8.18.0",
@@ -2386,6 +2561,8 @@
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2408,35 +2585,10 @@
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/yaml-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/yaml-types/-/yaml-types-0.4.0.tgz",
-      "integrity": "sha512-XfbA30NUg4/LWUiplMbiufUiwYhgB9jvBhTWel7XQqjV+GaB79c2tROu/8/Tu7jO0HvDvnKWtBk5ksWRrhQ/0g==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 16",
-        "npm": ">= 7"
-      },
-      "peerDependencies": {
-        "yaml": "^2.3.0"
       }
     },
     "node_modules/yargs": {
@@ -2445,6 +2597,8 @@
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -2464,6 +2618,8 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2474,6 +2630,8 @@
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -2496,6 +2654,8 @@
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "start": "node ./server.js",
     "lint": "eslint --max-warnings=0 .",
     "lint-fix": "eslint --fix .",
-    "test": "npm run test:puppeteer:chrome",
-    "test:puppeteer:chrome": "x-test --client=puppeteer --url=http://127.0.0.1:8080/test/ --coverage=true",
+    "test": "x-test",
     "type": "tsc",
     "bump": "./bump.sh"
   },
@@ -42,14 +41,14 @@
   ],
   "devDependencies": {
     "@netflix/eslint-config": "3.0.0",
-    "@netflix/x-test-cli": "1.0.0-rc.2",
+    "@netflix/x-test-cli": "1.0.0-rc.5",
     "eslint": "10.1.0",
     "eslint-plugin-jsdoc": "62.8.0",
     "globals": "17.4.0",
     "typescript": "6.0.2"
   },
   "engines": {
-    "node": ">=20.18",
+    "node": ">=22",
     "npm": ">=10.8"
   },
   "contributors": [

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,4 @@
-import { test, coverage } from '../x-test.js';
-
-coverage('../x-test-reporter.js', 65);
-coverage('../x-test-root.js', 71);
-coverage('../x-test-suite.js', 96);
-coverage('../x-test-tap.js', 100);
-coverage('../x-test.js', 100);
+import { test } from '../x-test.js';
 
 test('./test-reporter.html');
 test('./test-suite.html');

--- a/test/test-root.js
+++ b/test/test-root.js
@@ -5,18 +5,12 @@ import { XTestRoot } from '../x-test-root.js';
 const getContext = () => {
   const state = {
     ended: false,
-    waiting: false,
     children: [],
     stepIds: [],
     steps: {},
     tests: {},
     describes: {},
     its: {},
-    coverage: false,
-    coverages: {},
-    resolveCoverageValuePromise: null,
-    coverageValuePromise: null,
-    coverageValue: null,
     reporter: null,
   };
   function publish(type, data) {
@@ -68,14 +62,6 @@ describe('level', () => {
     const { context } = getContext();
     context.state.stepIds.push('testStepId');
     context.state.steps['testStepId'] = { type: 'test-end', testId: 'testTestId' };
-    const level = XTestRoot.level(context, 'testStepId');
-    assert(level === 0);
-  });
-
-  it('returns level = 0 for "coverage"', () => {
-    const { context } = getContext();
-    context.state.stepIds.push('testStepId');
-    context.state.steps['testStepId'] = { type: 'coverage', coverageId: 'testCoverageId' };
     const level = XTestRoot.level(context, 'testStepId');
     assert(level === 0);
   });
@@ -138,72 +124,6 @@ describe('end', () => {
     XTestRoot.end(context);
     assert(context.state.ended === true);
   });
-
-  it('marks waiting as false', () => {
-    const { context } = getContext();
-    context.state.waiting = true;
-    assert(context.state.waiting === true);
-    XTestRoot.end(context);
-    assert(context.state.waiting === false);
-  });
-
-  it('publishes that the test has ended', () => {
-    const { context } = getContext();
-    XTestRoot.end(context);
-    assert(context.publish.calls.length === 1);
-    assert(context.publish.calls[0][0] === 'x-test-root-end');
-  });
-});
-
-describe('analyzeHrefCoverage', () => {
-  it('test coverage', () => {
-    const url = new URL('/fake.js', import.meta.url).href;
-    const text = `\
-// Fake file to test coverage on.
-class MyFakeClass {
-  fakeFunction(fake) {
-    if (fake) {
-      /*
-       *
-       *
-       *
-       *
-       *
-       */
-    } else {
-      /*
-       *
-       *
-       *
-       *
-       *
-       */
-    }
-  }
-}
-
-export default MyFakeClass;
-`;
-const expectedOutput = `\
-1       |  // Fake file to test coverage on.
-…
-12      |      } else {
-13 !    |        /*
-…
-19 !    |         */
-20 !    |      }
-…
-25      |  `;
-    const js = [{
-      url,
-      text,
-      ranges: [{ start: 0, end: 162 }, { start: 239, end: 275 }],
-    }];
-    const analysis = XTestRoot.analyzeHrefCoverage(js, url, 95);
-    assert(analysis.ok === false);
-    assert(analysis.output === expectedOutput);
-    assert(analysis.percent === 72);
-  });
 });
 
 describe('collectFailureStepIds', () => {
@@ -226,14 +146,6 @@ describe('collectFailureStepIds', () => {
     assert(ids[0] === 's2');
   });
 
-  it('does not include failing coverage steps', () => {
-    const { context } = getContext();
-    context.state.stepIds.push('s1');
-    context.state.steps = { s1: { type: 'coverage', coverageId: 'c1' } };
-    context.state.coverages = { c1: { ok: false } };
-    const ids = XTestRoot.collectFailureStepIds(context);
-    assert(ids.length === 0);
-  });
 });
 
 describe('formatFailure', () => {

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -482,37 +482,6 @@ describe('itOnly', () => {
   });
 });
 
-describe('register', () => {
-  describe('coverage', () => {
-    it('publishes new coverage', () => {
-      const { context } = getContext();
-      context.state.testId = '123';
-      context.state.href = 'http://localhost:8080';
-      XTestSuite.coverage(context, './test.js', 99);
-      assert(context.publish.calls.length === 1);
-      assert(context.publish.calls[0][0] === 'x-test-suite-register');
-      assert(context.publish.calls[0][1].type === 'coverage');
-      assert(context.publish.calls[0][1].coverageId === '0');
-      assert(context.publish.calls[0][1].href === 'http://localhost:8080/test.js');
-      assert(context.publish.calls[0][1].goal === 99);
-    });
-
-    it('throws for bad goal value', () => {
-      const { context } = getContext();
-      context.state.href = 'http://localhost:8080';
-      const expected = `Unexpected goal percentage "101".`;
-      let actual;
-      try {
-        XTestSuite.coverage(context, './test.js', 101);
-      } catch (error) {
-        actual = error.message;
-      }
-      assert(context.publish.calls.length === 0);
-      assert(actual === expected, actual);
-    });
-  });
-});
-
 describe('waitFor', () => {
   it('adds a promise when called', () => {
     const { context } = getContext();

--- a/types/x-test.d.ts
+++ b/types/x-test.d.ts
@@ -1,5 +1,4 @@
 export function assert(ok: unknown, text?: string): asserts ok;
-export function coverage(href: string, goal: number): void;
 export function waitFor(promise: Promise<unknown>): Promise<void>;
 export function test(href: string): void;
 export function describe(text: string, callback: () => void): void;

--- a/x-test-reporter.js
+++ b/x-test-reporter.js
@@ -22,8 +22,6 @@ export class XTestReporter extends HTMLElement {
   /** @type {References} */
   #references;
   /** @type {boolean} */
-  #postRun = false;
-  /** @type {boolean} */
   #inFailures = false;
 
   /**
@@ -68,7 +66,7 @@ export class XTestReporter extends HTMLElement {
     if (localStorage.getItem('x-test-reporter-closed') !== 'true') {
       this.setAttribute('open', '');
     }
-    this.#references.testName.value = new URL(location.href).searchParams.get('x-test-name') ?? '';
+    this.#references.testName.value = new URL(location.href).searchParams.get('x-test-name-pattern') ?? '';
     this.#references.toggle.addEventListener('click', () => {
       this.hasAttribute('open') ? this.removeAttribute('open') : this.setAttribute('open', '');
       localStorage.setItem('x-test-reporter-closed', String(!this.hasAttribute('open')));
@@ -85,7 +83,7 @@ export class XTestReporter extends HTMLElement {
     };
     this.#references.form.addEventListener('reset', () => {
       const url = new URL(location.href);
-      url.searchParams.delete('x-test-name');
+      url.searchParams.delete('x-test-name-pattern');
       location.href = url.href;
     });
     /**
@@ -97,9 +95,9 @@ export class XTestReporter extends HTMLElement {
       const testName = formData.get('testName');
       const url = new URL(location.href);
       if (testName && typeof testName === 'string') {
-        url.searchParams.set('x-test-name', testName);
+        url.searchParams.set('x-test-name-pattern', testName);
       } else {
-        url.searchParams.delete('x-test-name');
+        url.searchParams.delete('x-test-name-pattern');
       }
       location.href = url.href;
     };
@@ -134,7 +132,7 @@ export class XTestReporter extends HTMLElement {
   tap(...tap) {
     const items = [];
     for (const text of tap) {
-      if (this.#postRun && text === '# Failures:') {
+      if (text === '# Failures:') {
         this.#inFailures = true;
       }
       const { tag, properties, attributes, failed, done } = XTestReporter.parse(text, this.#inFailures);
@@ -145,7 +143,6 @@ export class XTestReporter extends HTMLElement {
       }
       if (done) {
         this.removeAttribute('testing');
-        this.#postRun = true;
       }
       if (failed) {
         this.removeAttribute('ok');

--- a/x-test-root.js
+++ b/x-test-root.js
@@ -9,20 +9,11 @@ export class XTestRoot {
    */
   static initialize(context, href) {
     const url = new URL(href);
-    if (!url.searchParams.get('x-test-no-reporter')) {
-      context.state.reporter = new XTestReporter();
-      document.body.append(context.state.reporter);
-    }
-    context.state.coverage = url.searchParams.get('x-test-run-coverage') === '';
-    const nameParam = url.searchParams.get('x-test-name');
+    context.state.reporter = new XTestReporter();
+    document.body.append(context.state.reporter);
+    const nameParam = url.searchParams.get('x-test-name-pattern');
     context.state.filtering = !!nameParam;
     context.state.namePattern = nameParam ? new RegExp(nameParam) : null;
-    context.state.coverageValuePromise = new Promise(resolve => {
-      context.state.resolveCoverageValuePromise = (/** @type {any} */ value) => {
-        context.state.coverageValue = value;
-        resolve(context.state.coverageValue);
-      };
-    });
     const versionStepId = context.uuid();
     const exitStepId = context.uuid();
     context.state.stepIds.push(versionStepId, exitStepId);
@@ -30,12 +21,6 @@ export class XTestRoot {
     context.state.steps[exitStepId] = { stepId: exitStepId, type: 'exit', status: 'waiting' };
     context.subscribe((/** @type {any} */ event) => {
       switch (event.data.type) {
-        case 'x-test-client-ping':
-          XTestRoot.onPing(context);
-          break;
-        case 'x-test-client-coverage-result':
-          XTestRoot.onCoverageResult(context, event);
-          break;
         case 'x-test-root-defer':
           XTestRoot.onDefer(context, event);
           break;
@@ -59,16 +44,7 @@ export class XTestRoot {
     });
 
     // Run own tests in iframe.
-    url.searchParams.delete('x-test-no-reporter');
-    url.searchParams.delete('x-test-run-coverage');
     context.publish('x-test-suite-register', { type: 'test', testId: context.uuid(), href: url.href });
-  }
-
-  /**
-   * @param {any} context
-   */
-  static onPing(context) {
-    context.publish('x-test-root-pong', { ended: context.state.ended, waiting: context.state.waiting });
   }
 
   /**
@@ -146,13 +122,6 @@ export class XTestRoot {
         }
         return false;
       });
-      const coverageIndex = context.state.stepIds.findIndex((/** @type {any} */ candidateId) => {
-        const candidate = context.state.steps[candidateId];
-        if (candidate.type === 'coverage') {
-          return true;
-        }
-        return false;
-      });
       const exitIndex = context.state.stepIds.findLastIndex((/** @type {any} */ candidateId) => {
         const candidate = context.state.steps[candidateId];
         if (candidate.type === 'exit') {
@@ -162,9 +131,7 @@ export class XTestRoot {
       });
       const index = siblingTestEndIndex === -1
         ? parentTestEndIndex === -1
-          ? coverageIndex === -1
-            ? exitIndex
-            : coverageIndex
+          ? exitIndex
           : parentTestEndIndex + 1
         : siblingTestEndIndex + 1;
       const lastSiblingChildrenIndex = context.state.children.findLastIndex((/** @type {any} */ candidate) => {
@@ -173,14 +140,9 @@ export class XTestRoot {
       const parentTestChildrenIndex = context.state.children.findLastIndex((/** @type {any} */ candidate) => {
         return candidate.type === 'test' && context.state.tests[candidate.testId].testId === initiatorTestId;
       });
-      const firstCoverageChildrenIndex = context.state.children.findIndex((/** @type {any} */ candidate) => {
-        return candidate.type === 'coverage';
-      });
       const childrenIndex = lastSiblingChildrenIndex === -1
         ? parentTestChildrenIndex === -1
-          ? firstCoverageChildrenIndex === -1
-            ? context.state.children.length
-            : firstCoverageChildrenIndex
+          ? context.state.children.length
           : parentTestChildrenIndex + 1
         : lastSiblingChildrenIndex + 1;
       const testStartStepId = context.uuid();
@@ -303,30 +265,6 @@ export class XTestRoot {
 
   /**
    * @param {any} context
-   * @param {any} data
-   */
-  static registerCoverage(context, data) {
-    if (!context.state.ended) {
-      // New "coverage" goal. Queue it up.
-      const stepId = context.uuid();
-      const coverageId = data.coverageId;
-      const index = context.state.stepIds.findLastIndex((/** @type {any} */ candidateId) => {
-        const candidate = context.state.steps[candidateId];
-        if (candidate.type === 'exit') {
-          return true;
-        }
-        return false;
-      });
-      context.state.stepIds.splice(index, 0, stepId);
-      context.state.steps[stepId] = { stepId, type: 'coverage', coverageId: coverageId, status: 'waiting' };
-      context.state.coverages[coverageId] = data;
-      const childrenIndex = context.state.children.length;
-      context.state.children.splice(childrenIndex, 0, { type: 'coverage', coverageId });
-    }
-  }
-
-  /**
-   * @param {any} context
    * @param {any} event
    */
   static onRegister(context, event) {
@@ -344,9 +282,6 @@ export class XTestRoot {
           break;
         case 'it':
           XTestRoot.registerIt(context, data);
-          break;
-        case 'coverage':
-          XTestRoot.registerCoverage(context, data);
           break;
         default:
           throw new Error(`Unexpected registration type "${data.type}".`);
@@ -456,16 +391,6 @@ export class XTestRoot {
          const errorTap = XTestTap.yaml(yaml.message, yaml.severity, yaml.data, level);
          XTestRoot.output(context, stepId, tap, errorTap);
       }
-    }
-  }
-
-  /**
-   * @param {any} context
-   * @param {any} event
-   */
-  static onCoverageResult(context, event) {
-    if (!context.state.ended) {
-      context.state.resolveCoverageValuePromise(event.data.data);
     }
   }
 
@@ -609,39 +534,6 @@ export class XTestRoot {
    * @param {any} context
    * @param {any} stepId
    */
-  static kickoffCoverage(context, stepId) {
-    const step = context.state.steps[stepId];
-    const coverage = context.state.coverages[step.coverageId];
-    if (context.state.coverageValue) {
-      try {
-        const analysis = XTestRoot.analyzeHrefCoverage(context.state.coverageValue.js, coverage.href, coverage.goal);
-        Object.assign(coverage, { ok: analysis.ok, percent: analysis.percent, output: analysis.output });
-      } catch (error) {
-        Object.assign(coverage, { ok: false, percent: 0, output: '' });
-        XTestRoot.bail(context, error);
-      }
-    } else {
-      Object.assign(coverage, { ok: true, percent: 0, output: '', directive: 'SKIP' });
-    }
-    const ok = XTestRoot.ok(context, stepId);
-    const number = XTestRoot.number(context, stepId);
-    const text = XTestRoot.text(context, stepId);
-    const directive = XTestRoot.directive(context, stepId);
-    const level = XTestRoot.level(context, stepId);
-    const tap = XTestTap.testLine(ok, number, text, directive ?? undefined, level);
-    if (!ok) {
-      const errorTap = XTestTap.diagnostic(coverage.output, level);
-      XTestRoot.output(context, stepId, tap, errorTap);
-    } else {
-      XTestRoot.output(context, stepId, tap);
-    }
-    step.status = 'done';
-  }
-
-  /**
-   * @param {any} context
-   * @param {any} stepId
-   */
   static kickoffExit(context, stepId) {
     const count = XTestRoot.count(context, stepId);
     const planTap = XTestTap.plan(count);
@@ -656,7 +548,7 @@ export class XTestRoot {
         }
       }
     }
-    XTestRoot.output(context, stepId, planTap, ...failureTap);
+    XTestRoot.output(context, stepId, ...failureTap, planTap);
     context.state.steps[stepId].status = 'done';
     XTestRoot.end(context);
   }
@@ -707,17 +599,6 @@ export class XTestRoot {
   /**
    * @param {any} context
    */
-  static requestCoverageValue(context) {
-    context.state.waiting = true;
-    Promise.race([context.state.coverageValuePromise, context.timeout(5000)])
-      .then(() => { XTestRoot.check(context); })
-      .catch((/** @type {any} */ error) => { XTestRoot.bail(context, error); });
-    context.publish('x-test-root-coverage-request');
-  }
-
-  /**
-   * @param {any} context
-   */
   static check(context) {
     if (!context.state.ended) {
       // Look to see if any tests are running.
@@ -763,14 +644,6 @@ export class XTestRoot {
             case 'it':
               XTestRoot.kickoffIt(context, stepId);
               XTestRoot.check(context);
-              break;
-            case 'coverage':
-              if (!context.state.coverage || context.state.coverageValue) {
-                XTestRoot.kickoffCoverage(context, stepId);
-                XTestRoot.check(context);
-              } else if (!context.state.waiting) {
-                XTestRoot.requestCoverageValue(context);
-              }
               break;
             case 'exit':
               XTestRoot.kickoffExit(context, stepId);
@@ -885,9 +758,6 @@ export class XTestRoot {
           XTestRoot.queueOrOutput(context, tap, step.type);
         }
         break;
-      case 'coverage':
-        XTestRoot.handleCoverage(context, step);
-        break;
       case 'version':
         XTestRoot.log(context, ...tap);
         break;
@@ -948,20 +818,6 @@ export class XTestRoot {
       return true;
     }
     return false;
-  }
-
-  /**
-   * @param {any} context
-   * @param {any} step
-   * @returns {void}
-   */
-  static handleCoverage(context, step) {
-    const childIndex = context.state.children.findIndex((/** @type {any} */ child) =>
-      child.type === 'coverage' && child.coverageId === step.coverageId
-    );
-    if (childIndex !== -1) {
-      context.state.children.splice(childIndex, 1);
-    }
   }
 
   /**
@@ -1041,8 +897,6 @@ export class XTestRoot {
         return context.state.describes[child.describeId].children.every((/** @type {any} */ candidate) => XTestRoot.childOk(context, candidate, options));
       case 'it':
         return context.state.its[child.itId].ok || options?.todoOk && context.state.its[child.itId].directive === 'TODO';
-      case 'coverage':
-        return context.state.coverages[child.coverageId].ok;
       default:
         throw new Error(`Unexpected type "${child.type}".`);
     }
@@ -1062,8 +916,6 @@ export class XTestRoot {
         return XTestRoot.childOk(context, { type: 'describe', describeId: step.describeId }, { todoOk: true });
       case 'it':
         return XTestRoot.childOk(context, { type: 'it', itId: step.itId });
-      case 'coverage':
-        return XTestRoot.childOk(context, { type: 'coverage', coverageId: step.coverageId });
       default:
         throw new Error(`Unexpected type "${step.type}".`);
     }
@@ -1098,11 +950,6 @@ export class XTestRoot {
         const index = context.state.children.findIndex((/** @type {any} */ candidate) => candidate.testId === test.testId);
         return index + 1;
       }
-      case 'coverage': {
-        const coverage = context.state.coverages[step.coverageId];
-        const index = context.state.children.findIndex((/** @type {any} */ candidate) => candidate.coverageId === coverage.coverageId);
-        return index + 1;
-      }
       default:
         throw new Error(`Unexpected type "${step.type}".`);
     }
@@ -1126,10 +973,6 @@ export class XTestRoot {
         return context.state.describes[step.describeId].text.replace(/#/g, '*');
       case 'it':
         return context.state.its[step.itId].text.replace(/#/g, '*');
-      case 'coverage': {
-        const coverage = context.state.coverages[step.coverageId];
-        return `${coverage.goal}% coverage goal for ${coverage.href} (got ${coverage.percent.toFixed(2)}%)`;
-      }
       default:
         throw new Error(`Unexpected type "${step.type}".`);
     }
@@ -1164,8 +1007,6 @@ export class XTestRoot {
         return null;
       case 'it':
         return context.state.its[step.itId].directive;
-      case 'coverage':
-        return context.state.coverages[step.coverageId].directive;
       default:
         throw new Error(`Unexpected type "${step.type}".`);
     }
@@ -1183,7 +1024,6 @@ export class XTestRoot {
         return 1;
       case 'test-start':
       case 'test-end':
-      case 'coverage':
         return 0;
       case 'describe-plan':
         return context.state.describes[step.describeId].parents.length + 1;
@@ -1258,66 +1098,5 @@ export class XTestRoot {
    */
   static end(context) {
     context.state.ended = true;
-    context.state.waiting = false;
-    context.publish('x-test-root-end');
-  }
-
-  /**
-   * @param {any} coverageValue
-   * @param {any} href
-   * @param {any} goal
-   * @returns {{ok: boolean, percent: number, output: string}}
-   */
-  static analyzeHrefCoverage(coverageValue, href, goal) {
-    const set = new Set();
-    let text = '';
-    for (const item of (coverageValue ?? [])) {
-      if (item.url === href) {
-        text = item.text;
-        for (const range of item.ranges) {
-          for (let i = range.start; i < range.end; i++) {
-            set.add(i);
-          }
-        }
-      }
-    }
-    const ranges = [];
-    const state = { used: set.has(0), start: 0 };
-    for (let index = 0; index < text.length; index++) {
-      const used = set.has(index);
-      if (used !== state.used) {
-        ranges.push({ used: state.used, start: state.start, end: index });
-        Object.assign(state, { used, start: index });
-      }
-    }
-    ranges.push({ used: state.used, start: state.start, end: text.length });
-    let output = '';
-    let lineNumber = 1;
-    for (const range of ranges) {
-      const splitLines = text.slice(range.start, range.end).split('\n');
-      const lines = [];
-      for (let iii = 0; iii < splitLines.length; iii++) {
-        const line = splitLines[iii];
-        if (lineNumber === 1 || iii > 0) {
-          lines.push(`${String(lineNumber++ + (range.used ? '' : ' !')).padEnd(8, ' ')}|  ${line}`);
-        } else {
-          lines.push(line);
-        }
-      }
-      let formattedLines = lines;
-      if (range.used) {
-        if (formattedLines.length > 3) {
-          formattedLines = [...formattedLines.slice(0, 1), '\u2026', ...formattedLines.slice(-1)];
-        }
-      } else {
-        if (formattedLines.length > 5) {
-          formattedLines = [...formattedLines.slice(0, 2), '\u2026', ...formattedLines.slice(-2)];
-        }
-      }
-      output += range.used ? `${formattedLines.join('\n')}` : `${formattedLines.join('\n')}`;
-    }
-    const percent = set.size / text.length * 100;
-    const ok = percent >= goal;
-    return { ok, percent, output };
   }
 }

--- a/x-test-suite.js
+++ b/x-test-suite.js
@@ -117,22 +117,6 @@ export class XTestSuite {
   /**
    * @param {any} context
    * @param {any} href
-   * @param {any} goal
-   */
-  static coverage(context, href, goal) {
-    if (context && !context.state.bailed) {
-      if (!(goal >= 0 && goal <= 100)) {
-        throw new Error(`Unexpected goal percentage "${goal}".`);
-      }
-      const coverageId = context.uuid();
-      const url = new URL(href, context.state.href);
-      context.publish('x-test-suite-register', { type: 'coverage', coverageId, href: url.href, goal });
-    }
-  }
-
-  /**
-   * @param {any} context
-   * @param {any} href
    */
   static test(context, href) {
     if (context && !context.state.bailed && !context.state.ready) {

--- a/x-test.config.js
+++ b/x-test.config.js
@@ -1,0 +1,13 @@
+export default {
+  url: 'http://127.0.0.1:8080/test/',
+  client: 'puppeteer',
+  browser: 'chromium',
+  coverage: true,
+  coverageTargets: {
+    './x-test.js':          { lines: 100 },
+    './x-test-tap.js':      { lines: 100 },
+    './x-test-suite.js':    { lines: 95 },
+    './x-test-root.js':     { lines: 78 },
+    './x-test-reporter.js': { lines: 70 },
+  },
+};

--- a/x-test.js
+++ b/x-test.js
@@ -14,16 +14,6 @@ import { XTestSuite } from './x-test-suite.js';
 export const assert = (ok, text) => XTestSuite.assert(suiteContext, ok, text);
 
 /**
- * Register coverage percentage goal for a given file.
- * @example
- *   coverage('../foo.js', 87);
- * @param {string} href - The URL/path to the file to check coverage for
- * @param {number} goal - The coverage percentage goal (0-100)
- * @returns {void}
- */
-export const coverage = (href, goal) => XTestSuite.coverage(suiteContext, href, goal);
-
-/**
  * Force test suite registration to remain open until promise resolves.
  * @example
  *   const barsPromise = fetch('https://foo/api/v2/bars').then(response => response.json());
@@ -165,11 +155,9 @@ function addUnhandledrejectionListener(callback) {
 let suiteContext = null;
 if (!frameElement?.getAttribute('data-x-test-test-id')) {
   const state = {
-    ended: false, waiting: false, children: [], stepIds: [], steps: {},
-    tests: {}, describes: {}, its: {}, coverage: false, coverages: {},
-    resolveCoverageValuePromise: null, coverageValuePromise: null,
-    coverageValue: null, reporter: null, filtering: false, queue: [],
-    queueing: false,
+    ended: false, children: [], stepIds: [], steps: {},
+    tests: {}, describes: {}, its: {}, reporter: null,
+    filtering: false, queue: [], queueing: false,
   };
   const rootContext = {
     state, uuid, publish, subscribe, timeout: XTestCommon.timeout,


### PR DESCRIPTION
Changes:

- “?x-test-name” renamed to “?x-test-name-pattern”.
- Removed support for “?x-test-no-reporter”.
- Coverage responsibility moved to CLI (deleted from here).
- Load event handshake deleted (CLI just reads TAP stream now).