### PR TITLE
Ditch `waitFor`, use JSON Modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Asynchronous registration via `waitFor` is removed — synchronous imports
+  (including `import ... with { type: 'json' }`) handle fixture data, and `it`
+  callbacks may still be async for per-test work (#80).
 - The `coverage()` API, the `x-test-run-coverage` URL
   parameter, and all associated TAP output have been removed. Coverage
   analysis is now the exclusive responsibility of `@netflix/x-test-cli` (#99).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ the separate `@netflix/x-test-cli` package.
 
 #### Browser Components
 1. **x-test.js** - Main library entry point containing:
-   - Public API exports (`it`, `describe`, `assert`, `test`, `coverage`, `waitFor`)
+   - Public API exports (`it`, `describe`, `assert`, `test`)
    - BroadcastChannel-based communication setup
    - Root/suite context initialization logic
    - UUID generation and utility functions
@@ -104,8 +104,7 @@ When writing tests:
 - Use `it(description, callback, timeout)` for individual test cases
 - Use `describe(description, callback)` for logical grouping
 - Use `assert(condition, message)` for assertions
-- Use `coverage(href, percentage)` to set coverage goals
-- Use `waitFor(promise)` to delay test completion until promise resolves
+- `it` callbacks may be async; `describe` callbacks must be synchronous
 - Use `.skip`, `.only`, `.todo` modifiers as needed on both `describe` and `it`
 
 ## Automation and CI/CD

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The following are exposed in the testing interface:
 - `describe.skip`: Skip all `it` tests in this group.
 - `describe.only`: Skip all other `describe` groups and `it` tests.
 - `describe.todo`: Mark all `it` tests within this group as _todo_.
-- `waitFor`: Ensures test registration remains open until given promise settles.
 - `assert`: Simple assertion call that throws if the boolean input is false-y.
 - `assert.deepEqual`: Strict deep-equality assertion for primitives, plain objects, and arrays.
 
@@ -37,11 +36,54 @@ The following parameters can be passed in via query params on the url:
 
 ## Execution
 
-Both `test` and `it` calls will execute _in order_**. `test` calls will boot the
+Both `test` and `it` calls will execute _in order_. `test` calls will boot the
 given html page in an iframe. Such iframes are run one-at-a-time. All invoked
 `it` calls await the completion of previously-invoked `it` calls.
 
-**This is not the case if you nest `it`--but that's an anti-pattern anyhow.
+## Recipes
+
+### Data-driven tests from a JSON fixture
+
+Use [Import Attributes / JSON Modules][json-modules] to pull fixture data
+synchronously at module-load time. Because the data is available before any `it`
+call, you can declare one test per row without any async bookkeeping:
+
+```js
+import data from './my-fixture.json' with { type: 'json' };
+import { it, assert } from '../x-test.js';
+
+for (const testCase of data) {
+  it(`testing ${testCase.name}`, () => {
+    assert(testCase.expected === testCase.actual, testCase.name);
+  });
+}
+```
+
+### Shared async fixture across multiple `it`s
+
+If multiple tests need the same result of an async operation, kick off one
+promise at module scope and `await` it inside each `it`. The promise resolves
+once; every `it` that awaits it gets the same value. Registration stays
+synchronous — only the test bodies do async work.
+
+```js
+import { it, assert } from '../x-test.js';
+
+const fetchPromise = fetch('/api/widgets').then(response => response.text());
+
+it('has widgets', async () => {
+  const body = await fetchPromise;
+  assert(body.length > 0);
+});
+
+it('body mentions a known widget', async () => {
+  const body = await fetchPromise;
+  assert(body.includes('sprocket'));
+});
+```
+
+Both patterns compose: import a JSON fixture for one thing, kick off a shared
+promise for another, and mix them freely in the same test file.
 
 ## Test Filtering
 
@@ -61,3 +103,5 @@ For automated testing with a Node.js CLI, see the
 
 There are many TAP formatters. Importantly, as long as you can pipe the TAP
 output to another program, the output should be interoperable.
+
+[json-modules]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with

--- a/test/test-scratch.js
+++ b/test/test-scratch.js
@@ -1,4 +1,4 @@
-import { it, describe, assert, waitFor } from '../x-test.js';
+import { it, describe, assert } from '../x-test.js';
 
 describe.only('this wrapper exercises describe only logic', () => {
   describe.skip('this wrapper exercises describe skip logic', () => {
@@ -39,14 +39,3 @@ describe.only('interval', () => {
     assert(true);
   }, 0);
 });
-
-// It’s difficult to write a test that proves this works, for now, you have to
-//  verify that this is indeed included in the output TAP.
-const { promise, resolve } = Promise.withResolvers();
-promise.then(() => {
-  it.only('asynchronously registered tests work', () => {
-    assert(true);
-  });
-});
-setTimeout(resolve, 0);
-waitFor(promise);

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -8,9 +8,7 @@ const getContext = () => {
     href: null,
     callbacks: {},
     bailed: false,
-    waitForId: null,
     ready: false,
-    promises: [],
     parents: [],
   };
   function publish(type, data) {
@@ -74,7 +72,7 @@ const getContext = () => {
 describe('initialize', () => {
   it('sets up default state and publishes when ready', async () => {
     const { context } = getContext();
-    XTestSuite.initialize(context, '123', 'http://localhost:8080');
+    await XTestSuite.initialize(context, '123', 'http://localhost:8080');
     assert(context.state.testId === '123');
     assert(context.state.href === 'http://localhost:8080');
     assert(context.state.parents.length === 1);
@@ -82,31 +80,24 @@ describe('initialize', () => {
     assert(context.state.parents[0].testId === '123');
     assert(context.addErrorListener.calls.length === 1);
     assert(context.addUnhandledrejectionListener.calls.length === 1);
-    assert(context.publish.calls.length === 1);
-    assert(context.publish.calls[0][0] === 'x-test-suite-initialize');
-    assert(context.publish.calls[0][1].testId === '123');
-    assert(context.state.waitForId === '0');
-    assert(context.state.promises.length === 1);
-    assert(context.state.ready === false);
-    await Promise.all(context.state.promises);
     assert(context.state.ready === true);
     assert(context.publish.calls.length === 2);
+    assert(context.publish.calls[0][0] === 'x-test-suite-initialize');
+    assert(context.publish.calls[0][1].testId === '123');
     assert(context.publish.calls[1][0] === 'x-test-suite-ready');
     assert(context.publish.calls[1][1].testId === '123');
   });
 
   it('marks state as bailed when any test bails', async () => {
     const { context } = getContext();
-    XTestSuite.initialize(context, '123', 'http://localhost:8080');
-    await Promise.all(context.state.promises);
+    await XTestSuite.initialize(context, '123', 'http://localhost:8080');
     context.publish('x-test-suite-bail');
     assert(context.state.bailed === true);
   });
 
   it('runs a test when told, ok', async () => {
     const { context } = getContext();
-    XTestSuite.initialize(context, '123', 'http://localhost:8080');
-    await Promise.all(context.state.promises);
+    await XTestSuite.initialize(context, '123', 'http://localhost:8080');
     let called = false;
     context.state.callbacks['testItId'] = () => { called = true; };
     assert(called === false);
@@ -125,8 +116,7 @@ describe('initialize', () => {
 
   it('runs a test when told, skip', async () => {
     const { context } = getContext();
-    XTestSuite.initialize(context, '123', 'http://localhost:8080');
-    await Promise.all(context.state.promises);
+    await XTestSuite.initialize(context, '123', 'http://localhost:8080');
     let called = false;
     context.state.callbacks['testItId'] = () => { called = true; };
     assert(called === false);
@@ -145,8 +135,7 @@ describe('initialize', () => {
 
   it('runs a test when told, not ok', async () => {
     const { context } = getContext();
-    XTestSuite.initialize(context, '123', 'http://localhost:8080');
-    await Promise.all(context.state.promises);
+    await XTestSuite.initialize(context, '123', 'http://localhost:8080');
     let called = false;
     context.state.callbacks['testItId'] = () => {
       called = true;
@@ -168,8 +157,7 @@ describe('initialize', () => {
 
   it('runs a test when told, todo, ok', async () => {
     const { context } = getContext();
-    XTestSuite.initialize(context, '123', 'http://localhost:8080');
-    await Promise.all(context.state.promises);
+    await XTestSuite.initialize(context, '123', 'http://localhost:8080');
     let called = false;
     context.state.callbacks['testItId'] = () => { called = true; };
     assert(called === false);
@@ -188,8 +176,7 @@ describe('initialize', () => {
 
   it('runs a test when told, todo, not ok', async () => {
     const { context } = getContext();
-    XTestSuite.initialize(context, '123', 'http://localhost:8080');
-    await Promise.all(context.state.promises);
+    await XTestSuite.initialize(context, '123', 'http://localhost:8080');
     let called = false;
     context.state.callbacks['testItId'] = () => {
       called = true;
@@ -211,8 +198,7 @@ describe('initialize', () => {
 
   it('closes registration after it is ready', async () => {
     const { context } = getContext();
-    XTestSuite.initialize(context, '123', 'http://localhost:8080');
-    await Promise.all(context.state.promises);
+    await XTestSuite.initialize(context, '123', 'http://localhost:8080');
     assert(context.publish.calls.length === 2);
     assert(context.publish.calls[0][0] === 'x-test-suite-initialize');
     assert(context.publish.calls[1][0] === 'x-test-suite-ready');
@@ -625,46 +611,6 @@ describe('deepEqual', () => {
 
   it('is a no-op when context is bailed', () => {
     XTestSuite.deepEqual({ state: { bailed: true } }, 1, 2, 'should not throw');
-  });
-});
-
-describe('waitFor', () => {
-  it('adds a promise when called', () => {
-    const { context } = getContext();
-    assert(context.state.promises.length === 0);
-    const promise = Promise.resolve();
-    XTestSuite.waitFor(context, promise);
-    assert(context.state.promises.length === 1);
-  });
-
-  it('publishes "x-test-ready" when resolved', async () => {
-    const { context } = getContext();
-    context.state.testId = '123';
-    const promise = Promise.resolve();
-    await XTestSuite.waitFor(context, promise);
-    assert(context.publish.calls.length === 1);
-    assert(context.publish.calls[0][0] === 'x-test-suite-ready');
-    assert(context.publish.calls[0][1].testId === '123');
-  });
-
-  it('awaits resolution of all promises to publish "x-test-ready"', async () => {
-    const { context } = getContext();
-    let resolvePromise1, resolvePromise2, resolvePromise3;
-    const promise1 = new Promise(resolve => { resolvePromise1 = resolve; });
-    const promise2 = new Promise(resolve => { resolvePromise2 = resolve; });
-    const promise3 = new Promise(resolve => { resolvePromise3 = resolve; });
-    XTestSuite.waitFor(context, promise1);
-    XTestSuite.waitFor(context, promise2);
-    XTestSuite.waitFor(context, promise3);
-    resolvePromise1();
-    await new Promise(resolve => setTimeout(resolve));
-    assert(context.publish.calls.length === 0);
-    resolvePromise2();
-    await new Promise(resolve => setTimeout(resolve));
-    assert(context.publish.calls.length === 0);
-    resolvePromise3();
-    await new Promise(resolve => setTimeout(resolve));
-    assert(context.publish.calls.length === 1);
   });
 });
 

--- a/types/x-test.d.ts
+++ b/types/x-test.d.ts
@@ -13,7 +13,6 @@ export namespace assert {
      */
     function deepEqual<T>(actual: unknown, expected: T, text?: string): asserts actual is T;
 }
-export function waitFor(promise: Promise<unknown>): Promise<void>;
 export function test(href: string): void;
 export function describe(text: string, callback: () => void): void;
 export namespace describe {

--- a/x-test-suite.js
+++ b/x-test-suite.js
@@ -6,7 +6,7 @@ export class XTestSuite {
    * @param {any} testId
    * @param {any} href
    */
-  static initialize(context, testId, href) {
+  static async initialize(context, testId, href) {
     Object.assign(context.state, { testId, href });
     context.publish('x-test-suite-initialize', { testId });
     context.state.parents.push({ type: 'test', testId });
@@ -33,8 +33,14 @@ export class XTestSuite {
       XTestSuite.bail(context, event.reason);
     });
 
-    // Keep registration open until _at least_ DOMContentLoaded.
-    XTestSuite.waitFor(context, context.domContentLoadedPromise);
+    // The registration window stays open until “DOMContentLoaded”, which allows
+    //  folks to import fixtures via JSON Modules and register tests before
+    //  registration ends. Note that this does _NOT_ support top-level awaits.
+    await context.domContentLoadedPromise;
+    if (!context.state.bailed) {
+      context.state.ready = true;
+      context.publish('x-test-suite-ready', { testId: context.state.testId });
+    }
   }
 
   /**
@@ -329,28 +335,5 @@ export class XTestSuite {
    */
   static itTodo(context, text, callback, interval) {
     XTestSuite.#itInner(context, text, callback, interval, 'TODO', null);
-  }
-
-  /**
-   * @param {any} context
-   * @param {any} promise
-   */
-  static async waitFor(context, promise) {
-    if (context && !context.state.bailed) {
-      if (!context.state.bailed) {
-        const waitForId = context.uuid();
-        context.state.waitForId = waitForId;
-        context.state.promises.push(promise);
-        try {
-          await Promise.all(context.state.promises);
-          if (context.state.waitForId === waitForId) {
-            context.state.ready = true;
-            context.publish('x-test-suite-ready', { testId: context.state.testId });
-          }
-        } catch (error) {
-          XTestSuite.bail(context, error);
-        }
-      }
-    }
   }
 }

--- a/x-test.config.js
+++ b/x-test.config.js
@@ -6,8 +6,8 @@ export default {
   coverageTargets: {
     './x-test.js':          { lines: 100 },
     './x-test-tap.js':      { lines: 100 },
-    './x-test-suite.js':    { lines: 96 },
-    './x-test-root.js':     { lines: 78 },
-    './x-test-reporter.js': { lines: 70 },
+    './x-test-suite.js':    { lines: 97 },
+    './x-test-root.js':     { lines: 77 },
+    './x-test-reporter.js': { lines: 71 },
   },
 };

--- a/x-test.js
+++ b/x-test.js
@@ -27,16 +27,6 @@ export const assert = (ok, text) => XTestSuite.assert(suiteContext, ok, text);
 assert.deepEqual = (actual, expected, text) => XTestSuite.deepEqual(suiteContext, actual, expected, text);
 
 /**
- * Force test suite registration to remain open until promise resolves.
- * @example
- *   const barsPromise = fetch('https://foo/api/v2/bars').then(response => response.json());
- *   waitFor(barsPromise);
- * @param {Promise<unknown>} promise - The promise to wait for before completing the test suite
- * @returns {Promise<void>}
- */
-export const waitFor = promise => XTestSuite.waitFor(suiteContext, promise);
-
-/**
  * Register a test to be run as a subsequent test suite.
  * @example
  *   test('./test-sibling.html');
@@ -179,8 +169,8 @@ if (!frameElement?.getAttribute('data-x-test-test-id')) {
   XTestRoot.initialize(rootContext, location.href);
 } else {
   const state = {
-    testId: null, href: null, callbacks: {}, bailed: false, waitForId: null,
-    ready: false, promises: [], parents: [],
+    testId: null, href: null, callbacks: {}, bailed: false,
+    ready: false, parents: [],
   };
   const domContentLoadedPromise = XTestCommon.domContentLoadedPromise(document);
   suiteContext = {


### PR DESCRIPTION
The `waitFor` function was exposed to allow you to await fixture data which would then be used to _register additional suites / tests_. With the baseline support of Import Attributes / JSON Modules, this can be done via static imports — because we wait until DOMContentLoaded to close the registration window, that all _just works_ now.