### PR TITLE
Rename “describe” to “suite” and “it” to “test”.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed `it` to `test` and `describe` to `suite` across the entire public API
+  and all internal concepts. `import { test, suite, assert, load }` is now the
+  canonical import.
 - Renamed `test(href)` load function to `load(href)`. Conceptually, when you
   call this function you “load a new frame with this href” (#99).
 - The `x-test-name` URL parameter has been renamed to `x-test-name-pattern`
@@ -24,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Asynchronous registration via `waitFor` is removed — synchronous imports
-  (including `import ... with { type: 'json' }`) handle fixture data, and `it`
+  (including `import ... with { type: 'json' }`) handle fixture data, and `test`
   callbacks may still be async for per-test work (#80).
 - The `coverage()` API, the `x-test-run-coverage` URL
   parameter, and all associated TAP output have been removed. Coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ code in this repository.
 
 The x-test utility is a simple, TAP-compliant test runner for the browser. It
 allows you to run tests directly in the browser using a familiar testing
-interface (`it`, `describe`, `assert`) while producing TAP Version 14 output.
+interface (`test`, `suite`, `assert`) while producing TAP Version 14 output.
 
 This repository contains the `@netflix/x-test` package - the browser-side test
 runner and utilities. For automated test execution and CI/CD integration, see
@@ -35,7 +35,7 @@ the separate `@netflix/x-test-cli` package.
 
 #### Browser Components
 1. **x-test.js** - Main library entry point containing:
-   - Public API exports (`it`, `describe`, `assert`, `load`)
+   - Public API exports (`test`, `suite`, `assert`, `load`)
    - BroadcastChannel-based communication setup
    - Root/suite context initialization logic
    - UUID generation and utility functions
@@ -49,7 +49,7 @@ the separate `@netflix/x-test-cli` package.
 3. **x-test-suite.js** - Individual test suite manager (`XTestSuite`) that:
    - Runs within iframes for isolated test execution
    - Handles test assertions, timeouts, and error catching
-   - Manages describe/it registration and callbacks
+   - Manages suite / test registration and callbacks
    - Communicates results back to root via BroadcastChannel
 
 4. **x-test-reporter.js** - Browser UI component (`XTestReporter`) that:
@@ -72,7 +72,7 @@ the separate `@netflix/x-test-cli` package.
 Each test defines an HTML document which runs in an iframe:
 - Root page coordinates overall test execution via BroadcastChannel
 - Each `load()` call creates a new iframe running that test file
-- Individual `it()` calls within each iframe execute sequentially with optional timeouts
+- Individual `test()` calls within each iframe execute sequentially with optional timeouts
 - Results bubble up through BroadcastChannel communication
 - Output is TAP Version 14 compliant
 
@@ -80,7 +80,7 @@ Each test defines an HTML document which runs in an iframe:
 
 - **Event-driven communication**: Uses BroadcastChannel for cross-context messaging
 - **TAP compliance**: All output follows TAP Version 14 specification
-- **Sequential execution**: Both `load()` and `it()` calls run in declared order
+- **Sequential execution**: Both `load()` and `test()` calls run in declared order
 - **Iframe isolation**: Each test runs in its own isolated iframe context
 - **Error handling**: Global error/rejection handlers with proper TAP bailout
 
@@ -101,11 +101,11 @@ Each test defines an HTML document which runs in an iframe:
 
 When writing tests:
 - Use `load('https://fully-qualified/path.html')` for iframe-based sub-tests
-- Use `it(description, callback, timeout)` for individual test cases
-- Use `describe(description, callback)` for logical grouping
+- Use `test(description, callback, timeout)` for individual test cases
+- Use `suite(description, callback)` for logical grouping
 - Use `assert(condition, message)` for assertions
-- `it` callbacks may be async; `describe` callbacks must be synchronous
-- Use `.skip`, `.only`, `.todo` modifiers as needed on both `describe` and `it`
+- `test` callbacks may be async; `suite` callbacks must be synchronous
+- Use `.skip`, `.only`, `.todo` modifiers as needed on both `suite` and `test`
 
 ## Automation and CI/CD
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,32 @@
 
 a simple, tap-compliant test runner for the browser
 
+```js
+import { load, suite, test, assert } from '@netflix/x-test';
+
+load('./test-other-important-things.html');
+
+suite('important feature', () => {
+  test('should work synchronously', () => {
+    assert(MyFeature.works() === 'worked', 'it did not work');
+  });
+
+  test('should work asynchronously', async () => {
+    assert(await MyFeature.isAwesome() === 'awesome', 'it is not awesome');
+  });
+
+  test('should match interface', () => {
+    assert.deepEqual(MyFeature.interface, { version: '123' }, 'does not match');
+  });
+});
+```
+
 ## Spec
 
 - importable as `type="module"`
 - is interoperable with TAP Version 14
 - nested sub-tests run in an iframe
-- has a recognizable testing interface (`it`, `describe`, `assert`)
+- has a recognizable testing interface (`suite`, `test`, `assert`)
 - can be used for automated testing
 
 ## Interface
@@ -16,15 +36,15 @@ a simple, tap-compliant test runner for the browser
 
 The following are exposed in the testing interface:
 
-- `load`: Creates a sub-test in an `iframe` based on given `src` html page.
-- `it`: The smallest testing unit — can be asynchronous.
-- `it.skip`: An `it` whose callback is not run and which will pass.
-- `it.only`: Skip all other `it` tests.
-- `it.todo`: An `it` whose callback _is_ run and is expected to fail.
-- `describe`: Simple synchronous grouping functionality.
-- `describe.skip`: Skip all `it` tests in this group.
-- `describe.only`: Skip all other `describe` groups and `it` tests.
-- `describe.todo`: Mark all `it` tests within this group as _todo_.
+- `load`: Creates a sub-test in an `iframe` based on given html `href`.
+- `test`: The smallest testing unit — can be asynchronous.
+- `test.skip`: A `test` whose callback is not run and which will pass.
+- `test.only`: Skip all other `test` tests.
+- `test.todo`: A `test` whose callback _is_ run and is expected to fail.
+- `suite`: Simple synchronous grouping functionality.
+- `suite.skip`: Skip all `test` tests in this group.
+- `suite.only`: Skip all other `suite` groups and `test` tests.
+- `suite.todo`: Mark all `test` tests within this group as _todo_.
 - `assert`: Simple assertion call that throws if the boolean input is false-y.
 - `assert.deepEqual`: Strict deep-equality assertion for primitives, plain objects, and arrays.
 
@@ -36,47 +56,47 @@ The following parameters can be passed in via query params on the url:
 
 ## Execution
 
-Both `load` and `it` calls will execute _in order_. `load` calls will boot the
+Both `load` and `test` calls will execute _in order_. `load` calls will boot the
 given html page in an iframe. Such iframes are run one-at-a-time. All invoked
-`it` calls await the completion of previously-invoked `it` calls.
+`test` calls await the completion of previously-invoked `test` calls.
 
 ## Recipes
 
 ### Data-driven tests from a JSON fixture
 
 Use [Import Attributes / JSON Modules][json-modules] to pull fixture data
-synchronously at module-load time. Because the data is available before any `it`
-call, you can declare one test per row without any async bookkeeping:
+synchronously at module-load time. Because the data is available before any
+`test` call, you can declare one test per row without any async bookkeeping:
 
 ```js
 import data from './my-fixture.json' with { type: 'json' };
-import { it, assert } from '../x-test.js';
+import { test, assert } from '../x-test.js';
 
 for (const testCase of data) {
-  it(`testing ${testCase.name}`, () => {
+  test(`testing ${testCase.name}`, () => {
     assert(testCase.expected === testCase.actual, testCase.name);
   });
 }
 ```
 
-### Shared async fixture across multiple `it`s
+### Shared async fixture across multiple `test`s
 
 If multiple tests need the same result of an async operation, kick off one
-promise at module scope and `await` it inside each `it`. The promise resolves
-once; every `it` that awaits it gets the same value. Registration stays
+promise at module scope and `await` it inside each `test`. The promise resolves
+once; every `test` that awaits it gets the same value. Registration stays
 synchronous — only the test bodies do async work.
 
 ```js
-import { it, assert } from '../x-test.js';
+import { test, assert } from '../x-test.js';
 
 const fetchPromise = fetch('/api/widgets').then(response => response.text());
 
-it('has widgets', async () => {
+test('has widgets', async () => {
   const body = await fetchPromise;
   assert(body.length > 0);
 });
 
-it('body mentions a known widget', async () => {
+test('body mentions a known widget', async () => {
   const body = await fetchPromise;
   assert(body.includes('sprocket'));
 });

--- a/demo/debug/index.js
+++ b/demo/debug/index.js
@@ -1,6 +1,6 @@
-import { it, assert } from '../../x-test.js';
+import { test, assert } from '../../x-test.js';
 
-it.todo('debuggable', () => {
+test.todo('debuggable', () => {
   const element = document.createElement('div');
   element.textContent = 'this should be green.';
   element.style.color = 'red';

--- a/demo/fail/index.js
+++ b/demo/fail/index.js
@@ -1,9 +1,9 @@
-import { assert, it } from '../../x-test.js';
+import { assert, test } from '../../x-test.js';
 
-it('bad assertion', () => {
+test('bad assertion', () => {
   assert(true === false); // eslint-disable-line no-constant-binary-expression
 });
 
-it('unexpected error', () => {
+test('unexpected error', () => {
   throw new Error('Oops!');
 });

--- a/demo/nest/nested/nested/index.js
+++ b/demo/nest/nested/nested/index.js
@@ -1,9 +1,9 @@
-import { assert, it, describe } from '../../../../x-test.js';
+import { assert, test, suite } from '../../../../x-test.js';
 
-describe('nest', () => {
-  describe('within', () => {
-    describe('tests', () => {
-      it('nested tests should be found', () => {
+suite('nest', () => {
+  suite('within', () => {
+    suite('tests', () => {
+      test('nested tests should be found', () => {
         assert(true);
       });
     });

--- a/demo/only/index.js
+++ b/demo/only/index.js
@@ -1,19 +1,19 @@
-import { it, describe, assert } from '../../x-test.js';
+import { test, suite, assert } from '../../x-test.js';
 
-it.only('this is run because it is flagged', () => {
+test.only('this is run because it is flagged', () => {
   assert(true);
 });
 
-it('this will get skipped because it is not flagged', () => {});
+test('this will get skipped because it is not flagged', () => {});
 
-describe('all these get skipped because they are not flagged', () => {
-  it('foo', () => {});
-  it('bar', () => {});
-  it('baz', () => {});
+suite('all these get skipped because they are not flagged', () => {
+  test('foo', () => {});
+  test('bar', () => {});
+  test('baz', () => {});
 });
 
-describe.only('all these are run because they are in a flagged group', () => {
-  it('yep, foo', () => { assert(true); });
-  it('yep, bar', () => { assert(true); });
-  it('yep, baz', () => { assert(true); });
+suite.only('all these are run because they are in a flagged group', () => {
+  test('yep, foo', () => { assert(true); });
+  test('yep, bar', () => { assert(true); });
+  test('yep, baz', () => { assert(true); });
 });

--- a/demo/pass/index.js
+++ b/demo/pass/index.js
@@ -1,5 +1,5 @@
-import { assert, it } from '../../x-test.js';
+import { assert, test } from '../../x-test.js';
 
-it('good assertion', () => {
+test('good assertion', () => {
   assert(true);
 });

--- a/demo/skip/index.js
+++ b/demo/skip/index.js
@@ -1,11 +1,11 @@
-import { it, describe } from '../../x-test.js';
+import { test, suite } from '../../x-test.js';
 
-it.skip('not to self: remember to write this test', () => {});
+test.skip('not to self: remember to write this test', () => {});
 
-it.skip('not to self: remember to write this other test', () => {});
+test.skip('not to self: remember to write this other test', () => {});
 
-describe.skip('skip all this stuff for now', () => {
-  it('foo', () => {});
-  it('bar', () => {});
-  it('baz', () => {});
+suite.skip('skip all this stuff for now', () => {
+  test('foo', () => {});
+  test('bar', () => {});
+  test('baz', () => {});
 });

--- a/demo/stale-race/keepalive.js
+++ b/demo/stale-race/keepalive.js
@@ -1,6 +1,6 @@
-import { assert, it } from '../../x-test.js';
+import { assert, test } from '../../x-test.js';
 
-it('runs past the 30s load-phase timer', async () => {
+test('runs past the 30s load-phase timer', async () => {
   await new Promise(resolve => { setTimeout(resolve, 35_000); });
   assert(true);
 }, 60_000);

--- a/demo/todo/index.js
+++ b/demo/todo/index.js
@@ -1,23 +1,23 @@
-import { it, describe } from '../../x-test.js';
+import { test, suite } from '../../x-test.js';
 
-it.todo('do the impossible one day', () => {
+test.todo('do the impossible one day', () => {
   throw new Error('cannot do the impossible');
 });
 
-it.todo('move mountains', () => {
+test.todo('move mountains', () => {
   throw new Error('mountain moving is not in your wheelhouse');
 });
 
-describe.todo('eventually, do all these things', () => {
-  it('go to the moon', () => {
+suite.todo('eventually, do all these things', () => {
+  test('go to the moon', () => {
     throw new Error('nope…');
   });
 
-  it('go to mars', () => {
+  test('go to mars', () => {
     throw new Error('nada…');
   });
 
-  it('go outside', () => {
+  test('go outside', () => {
     throw new Error('sigh…');
   });
 });

--- a/test/test-boot-a.js
+++ b/test/test-boot-a.js
@@ -1,7 +1,7 @@
-import { it, describe, assert } from '../x-test.js';
+import { test, suite, assert } from '../x-test.js';
 
-describe('<script type="module"> in <head>', () => {
-  it('registers into the same suite as body-placed scripts', () => {
+suite('<script type="module"> in <head>', () => {
+  test('registers into the same suite as body-placed scripts', () => {
     assert(true);
   });
 });

--- a/test/test-boot-b.js
+++ b/test/test-boot-b.js
@@ -1,7 +1,7 @@
-import { it, describe, assert } from '../x-test.js';
+import { test, suite, assert } from '../x-test.js';
 
-describe('first <script type="module"> in <body>', () => {
-  it('registers tests', () => {
+suite('first <script type="module"> in <body>', () => {
+  test('registers tests', () => {
     assert(true);
   });
 });

--- a/test/test-boot-c.js
+++ b/test/test-boot-c.js
@@ -1,7 +1,7 @@
-import { it, describe, assert } from '../x-test.js';
+import { test, suite, assert } from '../x-test.js';
 
-describe('second <script type="module"> in <body>', () => {
-  it('is not silently dropped after the first script evaluates', () => {
+suite('second <script type="module"> in <body>', () => {
+  test('is not silently dropped after the first script evaluates', () => {
     assert(true);
   });
 });

--- a/test/test-boot.html
+++ b/test/test-boot.html
@@ -3,22 +3,22 @@
   <head>
     <meta charset="utf-8">
     <!--
-      This suite documents how x-test boots across every supported
+      This page documents how x-test boots across every supported
       <script type="module"> arrangement: head placement, body placement,
-      multiple sibling scripts contributing to the same suite, and an
+      multiple sibling scripts contributing to the same frame, and an
       inline module script.
 
       The invariant holding it all together: x-test keeps the registration
       window open until DOMContentLoaded fires, which happens *after* every
       deferred module script has synchronously evaluated. Any combination
-      of these arrangements registers into a single suite.
+      of these arrangements registers into a single frame.
     -->
     <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-Tr3Xl0Jk5gT59jVAgb3/Gh7rLeEEE/DdwKxzketLPAU=';">
 
     <!-- Supports “x-test” loaded in <head>. -->
     <script type="module" src="../x-test.js"></script>
 
-    <!-- Supports a user test script placed in <head>. -->
+    <!-- Supports a user module script placed in <head>. -->
     <script type="module" src="test-boot-a.js"></script>
   </head>
   <body>
@@ -32,10 +32,10 @@
 
     <!-- Support inline module scripts. -->
     <script type="module">
-      import { it, describe, assert } from '../x-test.js';
+      import { suite, test, assert } from '../x-test.js';
 
-      describe('inline <script type="module">', () => {
-        it('registers alongside src-backed scripts', () => {
+      suite('inline <script type="module">', () => {
+        test('registers alongside src-backed scripts', () => {
           assert(true);
         });
       });

--- a/test/test-common.js
+++ b/test/test-common.js
@@ -1,4 +1,4 @@
-import { it, describe, assert } from '../x-test.js';
+import { test, suite, assert } from '../x-test.js';
 import { XTestCommon } from '../x-test-common.js';
 
 // A minimal fake target that records handlers so tests can fire events
@@ -13,21 +13,21 @@ const makeFakeTarget = (extra = {}) => {
   };
 };
 
-describe('timeout', () => {
-  it('resolves with XTestCommon.TIMEOUT after the interval', async () => {
+suite('timeout', () => {
+  test('resolves with XTestCommon.TIMEOUT after the interval', async () => {
     const result = await XTestCommon.timeout(1);
     assert(result === XTestCommon.TIMEOUT);
   });
 });
 
-describe('domContentLoadedPromise', () => {
-  it('resolves immediately when readyState is "complete"', async () => {
+suite('domContentLoadedPromise', () => {
+  test('resolves immediately when readyState is "complete"', async () => {
     const fake = makeFakeTarget({ readyState: 'complete' });
     const result = await XTestCommon.domContentLoadedPromise(/** @type {Document} */ (fake));
     assert(result === undefined);
   });
 
-  it('resolves on DOMContentLoaded when readyState is not "complete"', async () => {
+  test('resolves on DOMContentLoaded when readyState is not "complete"', async () => {
     const fake = makeFakeTarget({ readyState: 'loading' });
     const promise = XTestCommon.domContentLoadedPromise(/** @type {Document} */ (fake));
     fake.handlers.DOMContentLoaded();
@@ -36,8 +36,8 @@ describe('domContentLoadedPromise', () => {
   });
 });
 
-describe('iframeError', () => {
-  it('resolves with XTestCommon.IFRAME_ERROR when the error event fires', async () => {
+suite('iframeError', () => {
+  test('resolves with XTestCommon.IFRAME_ERROR when the error event fires', async () => {
     const fake = makeFakeTarget();
     const promise = XTestCommon.iframeError(fake);
     fake.handlers.error();
@@ -46,8 +46,8 @@ describe('iframeError', () => {
   });
 });
 
-describe('iframeLoad', () => {
-  it('resolves with XTestCommon.IFRAME_LOAD when the load event fires', async () => {
+suite('iframeLoad', () => {
+  test('resolves with XTestCommon.IFRAME_LOAD when the load event fires', async () => {
     const fake = makeFakeTarget();
     const promise = XTestCommon.iframeLoad(fake);
     fake.handlers.load();

--- a/test/test-frame.js
+++ b/test/test-frame.js
@@ -1,4 +1,4 @@
-import { it, describe, assert } from '../x-test.js';
+import { test, suite, assert } from '../x-test.js';
 import { XTestFrame } from '../x-test-frame.js';
 
 // Dependency injection.
@@ -69,8 +69,8 @@ const getContext = () => {
   return { context, injectError, injectUnhandledrejection };
 };
 
-describe('initialize', () => {
-  it('sets up default state and publishes when ready', async () => {
+suite('initialize', () => {
+  test('sets up default state and publishes when ready', async () => {
     const { context } = getContext();
     await XTestFrame.initialize(context, '123', 'http://localhost:8080');
     assert(context.state.frameId === '123');
@@ -88,20 +88,20 @@ describe('initialize', () => {
     assert(context.publish.calls[1][1].frameId === '123');
   });
 
-  it('marks state as bailed when any test bails', async () => {
+  test('marks state as bailed when any test bails', async () => {
     const { context } = getContext();
     await XTestFrame.initialize(context, '123', 'http://localhost:8080');
     context.publish('x-test-frame-bail');
     assert(context.state.bailed === true);
   });
 
-  it('runs a test when told, ok', async () => {
+  test('runs a test when told, ok', async () => {
     const { context } = getContext();
     await XTestFrame.initialize(context, '123', 'http://localhost:8080');
     let called = false;
-    context.state.callbacks['testItId'] = () => { called = true; };
+    context.state.callbacks['testTestId'] = () => { called = true; };
     assert(called === false);
-    context.publish('x-test-root-run', { itId: 'testItId' });
+    context.publish('x-test-root-run', { testId: 'testTestId' });
     assert(called === true);
     await new Promise(resolve => setTimeout(resolve));
     assert(context.publish.calls.length === 4);
@@ -109,18 +109,18 @@ describe('initialize', () => {
     assert(context.publish.calls[1][0] === 'x-test-frame-ready'); // From initialization (async).
     assert(context.publish.calls[2][0] === 'x-test-root-run'); // This is from our test.
     assert(context.publish.calls[3][0] === 'x-test-frame-result');
-    assert(context.publish.calls[3][1].itId === 'testItId');
+    assert(context.publish.calls[3][1].testId === 'testTestId');
     assert(context.publish.calls[3][1].ok === true);
     assert(context.publish.calls[3][1].error === null);
   });
 
-  it('runs a test when told, skip', async () => {
+  test('runs a test when told, skip', async () => {
     const { context } = getContext();
     await XTestFrame.initialize(context, '123', 'http://localhost:8080');
     let called = false;
-    context.state.callbacks['testItId'] = () => { called = true; };
+    context.state.callbacks['testTestId'] = () => { called = true; };
     assert(called === false);
-    context.publish('x-test-root-run', { itId: 'testItId', directive: 'SKIP' });
+    context.publish('x-test-root-run', { testId: 'testTestId', directive: 'SKIP' });
     assert(called === false);
     await new Promise(resolve => setTimeout(resolve));
     assert(context.publish.calls.length === 4);
@@ -128,21 +128,21 @@ describe('initialize', () => {
     assert(context.publish.calls[1][0] === 'x-test-frame-ready'); // From initialization (async).
     assert(context.publish.calls[2][0] === 'x-test-root-run'); // This is from our test.
     assert(context.publish.calls[3][0] === 'x-test-frame-result');
-    assert(context.publish.calls[3][1].itId === 'testItId');
+    assert(context.publish.calls[3][1].testId === 'testTestId');
     assert(context.publish.calls[3][1].ok === true);
     assert(context.publish.calls[3][1].error === null);
   });
 
-  it('runs a test when told, not ok', async () => {
+  test('runs a test when told, not ok', async () => {
     const { context } = getContext();
     await XTestFrame.initialize(context, '123', 'http://localhost:8080');
     let called = false;
-    context.state.callbacks['testItId'] = () => {
+    context.state.callbacks['testTestId'] = () => {
       called = true;
       throw new Error('test failure');
     };
     assert(called === false);
-    context.publish('x-test-root-run', { itId: 'testItId' });
+    context.publish('x-test-root-run', { testId: 'testTestId' });
     assert(called === true);
     await new Promise(resolve => setTimeout(resolve));
     assert(context.publish.calls.length === 4);
@@ -150,18 +150,18 @@ describe('initialize', () => {
     assert(context.publish.calls[1][0] === 'x-test-frame-ready'); // From initialization (async).
     assert(context.publish.calls[2][0] === 'x-test-root-run'); // This is from our test.
     assert(context.publish.calls[3][0] === 'x-test-frame-result');
-    assert(context.publish.calls[3][1].itId === 'testItId');
+    assert(context.publish.calls[3][1].testId === 'testTestId');
     assert(context.publish.calls[3][1].ok === false);
     assert(context.publish.calls[3][1].error.message === 'test failure');
   });
 
-  it('runs a test when told, todo, ok', async () => {
+  test('runs a test when told, todo, ok', async () => {
     const { context } = getContext();
     await XTestFrame.initialize(context, '123', 'http://localhost:8080');
     let called = false;
-    context.state.callbacks['testItId'] = () => { called = true; };
+    context.state.callbacks['testTestId'] = () => { called = true; };
     assert(called === false);
-    context.publish('x-test-root-run', { itId: 'testItId', directive: 'TODO' });
+    context.publish('x-test-root-run', { testId: 'testTestId', directive: 'TODO' });
     assert(called === true);
     await new Promise(resolve => setTimeout(resolve));
     assert(context.publish.calls.length === 4);
@@ -169,21 +169,21 @@ describe('initialize', () => {
     assert(context.publish.calls[1][0] === 'x-test-frame-ready'); // From initialization (async).
     assert(context.publish.calls[2][0] === 'x-test-root-run'); // This is from our test.
     assert(context.publish.calls[3][0] === 'x-test-frame-result');
-    assert(context.publish.calls[3][1].itId === 'testItId');
+    assert(context.publish.calls[3][1].testId === 'testTestId');
     assert(context.publish.calls[3][1].ok === true);
     assert(context.publish.calls[3][1].error === null);
   });
 
-  it('runs a test when told, todo, not ok', async () => {
+  test('runs a test when told, todo, not ok', async () => {
     const { context } = getContext();
     await XTestFrame.initialize(context, '123', 'http://localhost:8080');
     let called = false;
-    context.state.callbacks['testItId'] = () => {
+    context.state.callbacks['testTestId'] = () => {
       called = true;
       throw new Error('test failure');
     };
     assert(called === false);
-    context.publish('x-test-root-run', { itId: 'testItId', directive: 'TODO' });
+    context.publish('x-test-root-run', { testId: 'testTestId', directive: 'TODO' });
     assert(called === true);
     await new Promise(resolve => setTimeout(resolve));
     assert(context.publish.calls.length === 4);
@@ -191,26 +191,26 @@ describe('initialize', () => {
     assert(context.publish.calls[1][0] === 'x-test-frame-ready'); // From initialization (async).
     assert(context.publish.calls[2][0] === 'x-test-root-run'); // This is from our test.
     assert(context.publish.calls[3][0] === 'x-test-frame-result');
-    assert(context.publish.calls[3][1].itId === 'testItId');
+    assert(context.publish.calls[3][1].testId === 'testTestId');
     assert(context.publish.calls[3][1].ok === false);
     assert(context.publish.calls[3][1].error.message === 'test failure');
   });
 
-  it('closes registration after it is ready', async () => {
+  test('closes registration after it is ready', async () => {
     const { context } = getContext();
     await XTestFrame.initialize(context, '123', 'http://localhost:8080');
     assert(context.publish.calls.length === 2);
     assert(context.publish.calls[0][0] === 'x-test-frame-initialize');
     assert(context.publish.calls[1][0] === 'x-test-frame-ready');
     XTestFrame.load(context, './test.html');
-    XTestFrame.describe(context, 'nope', () => {});
-    XTestFrame.it(context, 'nope', () => {});
+    XTestFrame.suite(context, 'nope', () => {});
+    XTestFrame.test(context, 'nope', () => {});
     assert(context.publish.calls.length === 2); // doesn't get registered.
   });
 });
 
-describe('load', () => {
-  it('publishes new test', () => {
+suite('load', () => {
+  test('publishes new test', () => {
     const { context } = getContext();
     context.state.frameId = '123';
     context.state.href = 'http://localhost:8080';
@@ -224,129 +224,129 @@ describe('load', () => {
   });
 });
 
-describe('describe', () => {
-  it('publishes new describe-start and describe-end', () => {
+suite('suite', () => {
+  test('publishes new suite-start and suite-end', () => {
     const { context } = getContext();
     context.state.frameId = '123';
     context.state.parents = [{ type: 'frame', frameId: '123' }];
     const callback = () => {};
-    XTestFrame.describe(context, 'description', callback);
+    XTestFrame.suite(context, 'description', callback);
     assert(context.publish.calls.length === 2);
     assert(context.publish.calls[0][0] === 'x-test-frame-register');
-    assert(context.publish.calls[0][1].type === 'describe-start');
-    assert(context.publish.calls[0][1].describeId === '0');
+    assert(context.publish.calls[0][1].type === 'suite-start');
+    assert(context.publish.calls[0][1].suiteId === '0');
     assert(context.publish.calls[0][1].parents.length === 1);
     assert(context.publish.calls[0][1].parents[0].type === 'frame');
     assert(context.publish.calls[0][1].parents[0].frameId === '123');
     assert(context.publish.calls[0][1].text === 'description');
 
     assert(context.publish.calls[1][0] === 'x-test-frame-register');
-    assert(context.publish.calls[1][1].type === 'describe-end');
-    assert(context.publish.calls[1][1].describeId === '0');
+    assert(context.publish.calls[1][1].type === 'suite-end');
+    assert(context.publish.calls[1][1].suiteId === '0');
   });
 
-  it('respects current describe for multi-level nesting', () => {
+  test('respects current suite for multi-level nesting', () => {
     const { context } = getContext();
     context.state.frameId = '123';
-    context.state.parents = [{ type: 'frame', frameId: '123' }, { type: 'describe', describeId: '999' }];
+    context.state.parents = [{ type: 'frame', frameId: '123' }, { type: 'suite', suiteId: '999' }];
     const callback = () => {};
-    XTestFrame.describe(context, 'description', callback);
+    XTestFrame.suite(context, 'description', callback);
     assert(context.publish.calls.length === 2);
     assert(context.publish.calls[0][0] === 'x-test-frame-register');
-    assert(context.publish.calls[0][1].type === 'describe-start');
-    assert(context.publish.calls[0][1].describeId === '0');
+    assert(context.publish.calls[0][1].type === 'suite-start');
+    assert(context.publish.calls[0][1].suiteId === '0');
     assert(context.publish.calls[0][1].parents.length === 2);
     assert(context.publish.calls[0][1].parents[0].type === 'frame');
     assert(context.publish.calls[0][1].parents[0].frameId === '123');
-    assert(context.publish.calls[0][1].parents[1].type === 'describe');
-    assert(context.publish.calls[0][1].parents[1].describeId === '999');
+    assert(context.publish.calls[0][1].parents[1].type === 'suite');
+    assert(context.publish.calls[0][1].parents[1].suiteId === '999');
     assert(context.publish.calls[0][1].text === 'description');
 
     assert(context.publish.calls[1][0] === 'x-test-frame-register');
-    assert(context.publish.calls[1][1].type === 'describe-end');
-    assert(context.publish.calls[1][1].describeId === '0');
+    assert(context.publish.calls[1][1].type === 'suite-end');
+    assert(context.publish.calls[1][1].suiteId === '0');
   });
 
-  it('publishes nested describe registered in callback', () => {
+  test('publishes nested suite registered in callback', () => {
     const { context } = getContext();
     context.state.frameId = '123';
     context.state.parents = [{ type: 'frame', frameId: '123' }];
     const callback = () => {
       const innerCallback = () => {};
-      XTestFrame.describe(context, 'inner-description', innerCallback);
+      XTestFrame.suite(context, 'inner-description', innerCallback);
     };
-    XTestFrame.describe(context, 'description', callback);
+    XTestFrame.suite(context, 'description', callback);
     assert(context.publish.calls.length === 4);
     assert(context.publish.calls[0][0] === 'x-test-frame-register');
-    assert(context.publish.calls[0][1].type === 'describe-start');
-    assert(context.publish.calls[0][1].describeId === '0');
+    assert(context.publish.calls[0][1].type === 'suite-start');
+    assert(context.publish.calls[0][1].suiteId === '0');
     assert(context.publish.calls[0][1].parents.length === 1);
     assert(context.publish.calls[0][1].parents[0].type === 'frame');
     assert(context.publish.calls[0][1].parents[0].frameId === '123');
     assert(context.publish.calls[0][1].text === 'description');
 
     assert(context.publish.calls[1][0] === 'x-test-frame-register');
-    assert(context.publish.calls[1][1].type === 'describe-start');
-    assert(context.publish.calls[1][1].describeId === '1');
+    assert(context.publish.calls[1][1].type === 'suite-start');
+    assert(context.publish.calls[1][1].suiteId === '1');
     assert(context.publish.calls[1][1].parents.length === 2);
     assert(context.publish.calls[1][1].parents[0].type === 'frame');
     assert(context.publish.calls[1][1].parents[0].frameId === '123');
-    assert(context.publish.calls[1][1].parents[1].type === 'describe');
-    assert(context.publish.calls[1][1].parents[1].describeId === '0');
+    assert(context.publish.calls[1][1].parents[1].type === 'suite');
+    assert(context.publish.calls[1][1].parents[1].suiteId === '0');
     assert(context.publish.calls[1][1].text === 'inner-description');
 
     assert(context.publish.calls[2][0] === 'x-test-frame-register');
-    assert(context.publish.calls[2][1].type === 'describe-end');
-    assert(context.publish.calls[2][1].describeId === '1');
+    assert(context.publish.calls[2][1].type === 'suite-end');
+    assert(context.publish.calls[2][1].suiteId === '1');
 
     assert(context.publish.calls[3][0] === 'x-test-frame-register');
-    assert(context.publish.calls[3][1].type === 'describe-end');
-    assert(context.publish.calls[3][1].describeId === '0');
+    assert(context.publish.calls[3][1].type === 'suite-end');
+    assert(context.publish.calls[3][1].suiteId === '0');
   });
 
-  it('publishes nested it registered in callback', () => {
+  test('publishes nested test registered in callback', () => {
     const { context } = getContext();
     context.state.frameId = '123';
     context.state.parents = [{ type: 'frame', frameId: '123' }];
     const callback = () => {
       const innerCallback = () => {};
-      XTestFrame.it(context, 'inner-description', innerCallback);
+      XTestFrame.test(context, 'inner-description', innerCallback);
     };
-    XTestFrame.describe(context, 'description', callback);
+    XTestFrame.suite(context, 'description', callback);
     assert(context.publish.calls.length === 3);
     assert(context.publish.calls[0][0] === 'x-test-frame-register');
-    assert(context.publish.calls[0][1].type === 'describe-start');
-    assert(context.publish.calls[0][1].describeId === '0');
+    assert(context.publish.calls[0][1].type === 'suite-start');
+    assert(context.publish.calls[0][1].suiteId === '0');
     assert(context.publish.calls[0][1].parents.length === 1);
     assert(context.publish.calls[0][1].parents[0].type === 'frame');
     assert(context.publish.calls[0][1].parents[0].frameId === '123');
     assert(context.publish.calls[0][1].text === 'description');
 
     assert(context.publish.calls[1][0] === 'x-test-frame-register');
-    assert(context.publish.calls[1][1].type === 'it');
-    assert(context.publish.calls[1][1].itId === '1');
+    assert(context.publish.calls[1][1].type === 'test');
+    assert(context.publish.calls[1][1].testId === '1');
     assert(context.publish.calls[1][1].parents.length === 2);
     assert(context.publish.calls[1][1].parents[0].type === 'frame');
     assert(context.publish.calls[1][1].parents[0].frameId === '123');
-    assert(context.publish.calls[1][1].parents[1].type === 'describe');
-    assert(context.publish.calls[1][1].parents[1].describeId === '0');
+    assert(context.publish.calls[1][1].parents[1].type === 'suite');
+    assert(context.publish.calls[1][1].parents[1].suiteId === '0');
     assert(context.publish.calls[1][1].text === 'inner-description');
 
     assert(context.publish.calls[2][0] === 'x-test-frame-register');
-    assert(context.publish.calls[2][1].type === 'describe-end');
-    assert(context.publish.calls[2][1].describeId === '0');
+    assert(context.publish.calls[2][1].type === 'suite-end');
+    assert(context.publish.calls[2][1].suiteId === '0');
   });
 
-  it('bails for failures during describe callback', () => {
+  test('bails for failures during suite callback', () => {
     const { context } = getContext();
     context.state.frameId = '123';
     context.state.parents = [{ type: 'frame', frameId: '123' }];
     const callback = () => { throw new Error('test failure'); };
-    XTestFrame.describe(context, 'description', callback);
+    XTestFrame.suite(context, 'description', callback);
     assert(context.publish.calls.length === 2);
     assert(context.publish.calls[0][0] === 'x-test-frame-register');
-    assert(context.publish.calls[0][1].type === 'describe-start');
-    assert(context.publish.calls[0][1].describeId === '0');
+    assert(context.publish.calls[0][1].type === 'suite-start');
+    assert(context.publish.calls[0][1].suiteId === '0');
     assert(context.publish.calls[0][1].parents.length === 1);
     assert(context.publish.calls[0][1].parents[0].type === 'frame');
     assert(context.publish.calls[0][1].parents[0].frameId === '123');
@@ -357,13 +357,13 @@ describe('describe', () => {
     assert(context.publish.calls[1][1].error.message === 'test failure');
   });
 
-  it('throws if callback is not a function', () => {
+  test('throws if callback is not a function', () => {
     const { context } = getContext();
     const callback = null;
     const expected = 'Unexpected callback value "null".';
     let actual;
     try {
-      XTestFrame.describe(context, 'description', callback);
+      XTestFrame.suite(context, 'description', callback);
     } catch (error) {
       actual = error.message;
     }
@@ -372,17 +372,17 @@ describe('describe', () => {
   });
 });
 
-describe('it', () => {
-  it('publishes new it', () => {
+suite('test', () => {
+  test('publishes new test', () => {
     const { context } = getContext();
     context.state.frameId = '123';
     context.state.parents = [{ type: 'frame', frameId: '123' }];
     const callback = () => {};
-    XTestFrame.it(context, 'description', callback);
+    XTestFrame.test(context, 'description', callback);
     assert(context.publish.calls.length === 1);
     assert(context.publish.calls[0][0] === 'x-test-frame-register');
-    assert(context.publish.calls[0][1].type === 'it');
-    assert(context.publish.calls[0][1].itId === '0');
+    assert(context.publish.calls[0][1].type === 'test');
+    assert(context.publish.calls[0][1].testId === '0');
     assert(context.publish.calls[0][1].parents.length === 1);
     assert(context.publish.calls[0][1].parents[0].type === 'frame');
     assert(context.publish.calls[0][1].parents[0].frameId === '123');
@@ -395,27 +395,27 @@ describe('it', () => {
   let message = 'no error thrown';
   let passed = false;
   try {
-    it('this will break', 'this is expected to fail');
+    test('this will break', 'this is expected to fail');
   } catch (error) {
     message = error.message;
     passed = error.message === 'Unexpected callback value "this is expected to fail".';
   }
-  it('throws if “it” is not given a function as a callback', () => {
+  test('throws if "test" is not given a function as a callback', () => {
     assert(passed, message);
   });
 });
 
-describe('itSkip', () => {
-  it('publishes new skip', () => {
+suite('testSkip', () => {
+  test('publishes new skip', () => {
     const { context } = getContext();
     context.state.frameId = '123';
     context.state.parents = [{ type: 'frame', frameId: '123' }];
     const callback = () => {};
-    XTestFrame.itSkip(context, 'description', callback);
+    XTestFrame.testSkip(context, 'description', callback);
     assert(context.publish.calls.length === 1);
     assert(context.publish.calls[0][0] === 'x-test-frame-register');
-    assert(context.publish.calls[0][1].type === 'it');
-    assert(context.publish.calls[0][1].itId === '0');
+    assert(context.publish.calls[0][1].type === 'test');
+    assert(context.publish.calls[0][1].testId === '0');
     assert(context.publish.calls[0][1].parents.length === 1);
     assert(context.publish.calls[0][1].parents[0].type === 'frame');
     assert(context.publish.calls[0][1].parents[0].frameId === '123');
@@ -426,17 +426,17 @@ describe('itSkip', () => {
   });
 });
 
-describe('itTodo', () => {
-  it('publishes new todo', () => {
+suite('testTodo', () => {
+  test('publishes new todo', () => {
     const { context } = getContext();
     context.state.frameId = '123';
     context.state.parents = [{ type: 'frame', frameId: '123' }];
     const callback = () => {};
-    XTestFrame.itTodo(context, 'description', callback);
+    XTestFrame.testTodo(context, 'description', callback);
     assert(context.publish.calls.length === 1);
     assert(context.publish.calls[0][0] === 'x-test-frame-register');
-    assert(context.publish.calls[0][1].type === 'it');
-    assert(context.publish.calls[0][1].itId === '0');
+    assert(context.publish.calls[0][1].type === 'test');
+    assert(context.publish.calls[0][1].testId === '0');
     assert(context.publish.calls[0][1].parents.length === 1);
     assert(context.publish.calls[0][1].parents[0].type === 'frame');
     assert(context.publish.calls[0][1].parents[0].frameId === '123');
@@ -447,17 +447,17 @@ describe('itTodo', () => {
   });
 });
 
-describe('itOnly', () => {
-  it('publishes new only', () => {
+suite('testOnly', () => {
+  test('publishes new only', () => {
     const { context } = getContext();
     context.state.frameId = '123';
     context.state.parents = [{ type: 'frame', frameId: '123' }];
     const callback = () => {};
-    XTestFrame.itOnly(context, 'description', callback);
+    XTestFrame.testOnly(context, 'description', callback);
     assert(context.publish.calls.length === 1);
     assert(context.publish.calls[0][0] === 'x-test-frame-register');
-    assert(context.publish.calls[0][1].type === 'it');
-    assert(context.publish.calls[0][1].itId === '0');
+    assert(context.publish.calls[0][1].type === 'test');
+    assert(context.publish.calls[0][1].testId === '0');
     assert(context.publish.calls[0][1].parents.length === 1);
     assert(context.publish.calls[0][1].parents[0].type === 'frame');
     assert(context.publish.calls[0][1].parents[0].frameId === '123');
@@ -468,10 +468,10 @@ describe('itOnly', () => {
   });
 });
 
-describe('assert', () => {
+suite('assert', () => {
   const makeContext = () => ({ state: { bailed: false } });
 
-  it('defaults message to "not ok"', () => {
+  test('defaults message to "not ok"', () => {
     let message;
     try {
       XTestFrame.assert(makeContext(), false);
@@ -482,7 +482,7 @@ describe('assert', () => {
   });
 });
 
-describe('deepEqual', () => {
+suite('deepEqual', () => {
   const makeContext = () => ({ state: { bailed: false } });
   const expectOk = (actual, expected) => {
     XTestFrame.deepEqual(makeContext(), actual, expected);
@@ -506,7 +506,7 @@ describe('deepEqual', () => {
     assert(typeof message === 'string' && matcher.test(message), `got ${JSON.stringify(message)}`);
   };
 
-  it('passes for equal primitives', () => {
+  test('passes for equal primitives', () => {
     expectOk(1, 1);
     expectOk('a', 'a');
     expectOk(true, true);
@@ -516,80 +516,80 @@ describe('deepEqual', () => {
     expectOk(0n, 0n);
   });
 
-  it('distinguishes +0 and -0', () => {
+  test('distinguishes +0 and -0', () => {
     expectNotEqual(0, -0);
   });
 
-  it('fails for unequal primitives', () => {
+  test('fails for unequal primitives', () => {
     expectNotEqual(1, 2);
     expectNotEqual('a', 'b');
     expectNotEqual(true, false);
     expectNotEqual(null, undefined);
   });
 
-  it('compares plain objects by own keys', () => {
+  test('compares plain objects by own keys', () => {
     expectOk({ a: 1, b: 2 }, { b: 2, a: 1 });
     expectNotEqual({ a: 1 }, { a: 1, b: 2 });
     expectNotEqual({ a: 1 }, { a: 2 });
     expectNotEqual({ a: 1 }, { b: 1 });
   });
 
-  it('compares arrays strictly by length and index', () => {
+  test('compares arrays strictly by length and index', () => {
     expectOk([1, 2, 3], [1, 2, 3]);
     expectNotEqual([1, 2], [1, 2, 3]);
     expectNotEqual([1, 2, 3], [3, 2, 1]);
   });
 
-  it('distinguishes sparse arrays from arrays with explicit undefined', () => {
+  test('distinguishes sparse arrays from arrays with explicit undefined', () => {
     // eslint-disable-next-line no-sparse-arrays
     expectNotEqual([1,,3], [1, undefined, 3]);
   });
 
-  it('compares named properties on arrays', () => {
+  test('compares named properties on arrays', () => {
     const a = Object.assign([1, 2], { foo: 'bar' });
     const b = [1, 2];
     expectNotEqual(a, b);
   });
 
-  it('recurses into nested structures', () => {
+  test('recurses into nested structures', () => {
     expectOk({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] });
     expectNotEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 3 }] });
   });
 
-  it('supports null-prototype objects', () => {
+  test('supports null-prototype objects', () => {
     const a = Object.assign(Object.create(null), { x: 1 });
     const b = Object.assign(Object.create(null), { x: 1 });
     expectOk(a, b);
   });
 
-  it('fails for mixed null-prototype vs Object.prototype', () => {
+  test('fails for mixed null-prototype vs Object.prototype', () => {
     expectNotEqual(Object.create(null), {});
     expectNotEqual({}, Object.create(null));
   });
 
-  it('throws if either object has symbol-keyed properties', () => {
+  test('throws if either object has symbol-keyed properties', () => {
     const sym = Symbol('x');
     expectThrows({ [sym]: 1 }, {}, /deepEqual does not support symbol-keyed properties/);
     expectThrows({}, { [sym]: 1 }, /deepEqual does not support symbol-keyed properties/);
     expectThrows({ [sym]: 1 }, { [sym]: 1 }, /deepEqual does not support symbol-keyed properties/);
   });
 
-  it('rejects mixed object vs array', () => {
+  test('rejects mixed object vs array', () => {
     expectNotEqual({ 0: 'a', length: 1 }, ['a']);
   });
 
-  it('throws for unsupported class instances', () => {
+  test('throws for unsupported class instances', () => {
     expectThrows(new Map(), new Map(), /deepEqual only supports/);
     expectThrows(new Set(), new Set(), /deepEqual only supports/);
     expectThrows(new Date(0), new Date(0), /deepEqual only supports/);
     expectThrows(/a/, /a/, /deepEqual only supports/);
   });
 
-  it('throws for functions', () => {
+  test('throws for functions', () => {
     expectThrows(() => {}, () => {}, /deepEqual only supports/);
   });
 
-  it('uses custom message when provided', () => {
+  test('uses custom message when provided', () => {
     let message;
     try {
       XTestFrame.deepEqual({ state: { bailed: false } }, { a: 1 }, { a: 2 }, 'custom');
@@ -599,7 +599,7 @@ describe('deepEqual', () => {
     assert(message === 'custom');
   });
 
-  it('defaults message to "not deep equal"', () => {
+  test('defaults message to "not deep equal"', () => {
     let message;
     try {
       XTestFrame.deepEqual({ state: { bailed: false } }, 1, 2);
@@ -609,13 +609,13 @@ describe('deepEqual', () => {
     assert(message === 'not deep equal');
   });
 
-  it('is a no-op when context is bailed', () => {
+  test('is a no-op when context is bailed', () => {
     XTestFrame.deepEqual({ state: { bailed: true } }, 1, 2, 'should not throw');
   });
 });
 
-describe('bail', () => {
-  it('marks state as ended', () => {
+suite('bail', () => {
+  test('marks state as ended', () => {
     const error = new Error('error test');
     const { context } = getContext();
     assert(context.state.bailed === false);
@@ -623,7 +623,7 @@ describe('bail', () => {
     assert(context.state.bailed === true);
   });
 
-  it('publishes to parent frame', () => {
+  test('publishes to parent frame', () => {
     const error = new Error('error test');
     const { context } = getContext();
     context.state.frameId = '123';
@@ -635,14 +635,14 @@ describe('bail', () => {
   });
 });
 
-describe('error', () => {
-  it('turns error into basic object', () => {
+suite('error', () => {
+  test('turns error into basic object', () => {
     const testError = new Error('error test');
     const error = XTestFrame.createError(testError);
     assert(error.message = testError.toString());
     assert(error.stack = testError.stack);
   });
-  it('handles string errors', () => {
+  test('handles string errors', () => {
     const testError = 'error test';
     const error = XTestFrame.createError(testError);
     assert(error.message = testError.toString());

--- a/test/test-reporter.js
+++ b/test/test-reporter.js
@@ -1,8 +1,8 @@
-import { it, describe, assert } from '../x-test.js';
+import { test, suite, assert } from '../x-test.js';
 import { XTestReporter } from '../x-test-reporter.js';
 
-describe('render', () => {
-  it('prints out basic test', () => {
+suite('render', () => {
+  test('prints out basic test', () => {
     const tap = [
       'TAP version 14',
       '# Subtest: http://127.0.0.1:8080/test/',
@@ -35,7 +35,7 @@ describe('render', () => {
     element.remove();
   });
 
-  it('bails', () => {
+  test('bails', () => {
     const tap = [
       'TAP version 14',
       '# Subtest: http://127.0.0.1:8080/test/',
@@ -53,8 +53,8 @@ describe('render', () => {
   });
 });
 
-describe('parse', () => {
-  it('parses test', () => {
+suite('parse', () => {
+  test('parses test', () => {
     const output = '# Subtest: http://example.com/test.html';
     const result = XTestReporter.parse(output, false);
     assert(result.tag === 'a');
@@ -68,7 +68,7 @@ describe('parse', () => {
     assert(result.failed === false);
   });
 
-  it('parses bail test', () => {
+  test('parses bail test', () => {
     const output = 'Bail out! http://example.com/test.html';
     const result = XTestReporter.parse(output, false);
     assert(result.tag === 'a');
@@ -83,7 +83,7 @@ describe('parse', () => {
     assert(result.failed === true);
   });
 
-  it('parses diagnostic', () => {
+  test('parses diagnostic', () => {
     const output = '# something, anything';
     const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
@@ -96,7 +96,7 @@ describe('parse', () => {
     assert(result.failed === false);
   });
 
-  it('parses test line', () => {
+  test('parses test line', () => {
     const output = 'ok 145 - this cool thing i tested';
     const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
@@ -104,13 +104,13 @@ describe('parse', () => {
     assert(result.properties.innerText === output);
     assert(Object.keys(result.attributes).length === 3);
     assert(result.attributes.output === '');
-    assert(result.attributes.it === '');
+    assert(result.attributes.test === '');
     assert(result.attributes.ok === '');
     assert(result.done === false);
     assert(result.failed === false);
   });
 
-  it('parses "SKIP" test line', () => {
+  test('parses "SKIP" test line', () => {
     const output = 'ok 145 - this cool thing i tested # SKIP';
     const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
@@ -118,14 +118,14 @@ describe('parse', () => {
     assert(result.properties.innerText === output);
     assert(Object.keys(result.attributes).length === 4);
     assert(result.attributes.output === '');
-    assert(result.attributes.it === '');
+    assert(result.attributes.test === '');
     assert(result.attributes.ok === '');
     assert(result.attributes.directive === 'skip');
     assert(result.done === false);
     assert(result.failed === false);
   });
 
-  it('parses "TODO" test line', () => {
+  test('parses "TODO" test line', () => {
     const output = 'ok 145 - this cool thing i tested # TODO';
     const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
@@ -133,14 +133,14 @@ describe('parse', () => {
     assert(result.properties.innerText === output);
     assert(Object.keys(result.attributes).length === 4);
     assert(result.attributes.output === '');
-    assert(result.attributes.it === '');
+    assert(result.attributes.test === '');
     assert(result.attributes.ok === '');
     assert(result.attributes.directive === 'todo');
     assert(result.done === false);
     assert(result.failed === false);
   });
 
-  it('parses "not ok" test line', () => {
+  test('parses "not ok" test line', () => {
     const output = 'not ok 145 - this cool thing i tested';
     const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
@@ -148,12 +148,12 @@ describe('parse', () => {
     assert(result.properties.innerText === output);
     assert(Object.keys(result.attributes).length === 2);
     assert(result.attributes.output === '');
-    assert(result.attributes.it === '');
+    assert(result.attributes.test === '');
     assert(result.done === false);
     assert(result.failed === true);
   });
 
-  it('parses "not ok", "TODO" test line', () => {
+  test('parses "not ok", "TODO" test line', () => {
     const output = 'not ok 145 - this cool thing i tested # TODO tbd...';
     const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
@@ -161,13 +161,13 @@ describe('parse', () => {
     assert(result.properties.innerText === output);
     assert(Object.keys(result.attributes).length === 3);
     assert(result.attributes.output === '');
-    assert(result.attributes.it === '');
+    assert(result.attributes.test === '');
     assert(result.attributes.directive === 'todo');
     assert(result.done === false);
     assert(result.failed === false);
   });
 
-  it('parses version', () => {
+  test('parses version', () => {
     const output = 'TAP version 14';
     const result = XTestReporter.parse(output, false);
     assert(result.tag === 'div');
@@ -180,7 +180,7 @@ describe('parse', () => {
     assert(result.failed === false);
   });
 
-  it('parses in-failures bare URL as link', () => {
+  test('parses in-failures bare URL as link', () => {
     const output = '# http://example.com/test.html';
     const result = XTestReporter.parse(output, true);
     assert(result.tag === 'a');
@@ -188,26 +188,26 @@ describe('parse', () => {
     assert(result.attributes.failure === '');
   });
 
-  it('parses in-failures breadcrumb segment as failure', () => {
+  test('parses in-failures breadcrumb segment as failure', () => {
     const output = '# > this test failed';
     const result = XTestReporter.parse(output, true);
     assert(result.tag === 'div');
     assert(result.attributes.failure === '');
   });
 
-  it('parses in-failures yaml body as failure', () => {
+  test('parses in-failures yaml body as failure', () => {
     const output = '#     Error: nope';
     const result = XTestReporter.parse(output, true);
     assert(result.attributes.failure === '');
   });
 
-  it('tags in-failures blank separator as failure', () => {
+  test('tags in-failures blank separator as failure', () => {
     const output = '# ';
     const result = XTestReporter.parse(output, true);
     assert(result.attributes.failure === '');
   });
 
-  it('leaves pre-failures diagnostics untouched', () => {
+  test('leaves pre-failures diagnostics untouched', () => {
     const output = '# http://example.com/test.html';
     const result = XTestReporter.parse(output, false);
     assert(result.attributes.failure === undefined);

--- a/test/test-root.js
+++ b/test/test-root.js
@@ -1,4 +1,4 @@
-import { it, describe, assert } from '../x-test.js';
+import { test, suite, assert } from '../x-test.js';
 import { XTestRoot } from '../x-test-root.js';
 
 // Dependency injection.
@@ -9,8 +9,8 @@ const getContext = () => {
     stepIds: [],
     steps: {},
     frames: {},
-    describes: {},
-    its: {},
+    suites: {},
+    tests: {},
     reporter: null,
   };
   function publish(type, data) {
@@ -41,8 +41,8 @@ const getContext = () => {
   return { context };
 };
 
-describe('level', () => {
-  it('returns level = 1 for "load-plan"', () => {
+suite('level', () => {
+  test('returns level = 1 for "load-plan"', () => {
     const { context } = getContext();
     context.state.stepIds.push('testStepId');
     context.state.steps['testStepId'] = { type: 'frame-plan', frameId: 'testTestId' };
@@ -50,7 +50,7 @@ describe('level', () => {
     assert(level === 1);
   });
 
-  it('returns level = 0 for "load-start"', () => {
+  test('returns level = 0 for "load-start"', () => {
     const { context } = getContext();
     context.state.stepIds.push('testStepId');
     context.state.steps['testStepId'] = { type: 'frame-start', frameId: 'testTestId' };
@@ -58,7 +58,7 @@ describe('level', () => {
     assert(level === 0);
   });
 
-  it('returns level = 0 for "load-end"', () => {
+  test('returns level = 0 for "load-end"', () => {
     const { context } = getContext();
     context.state.stepIds.push('testStepId');
     context.state.steps['testStepId'] = { type: 'frame-end', frameId: 'testTestId' };
@@ -66,17 +66,17 @@ describe('level', () => {
     assert(level === 0);
   });
 
-  it.skip('returns level for "describe-plan"', () => {});
+  test.skip('returns level for "suite-plan"', () => {});
 
-  it.skip('returns level for "describe-start"', () => {});
+  test.skip('returns level for "suite-start"', () => {});
 
-  it.skip('returns level for "describe-end"', () => {});
+  test.skip('returns level for "suite-end"', () => {});
 
-  it.skip('returns level for "it"', () => {});
+  test.skip('returns level for "test"', () => {});
 });
 
-describe('count', () => {
-  it('returns count for "load-plan"', () => {
+suite('count', () => {
+  test('returns count for "load-plan"', () => {
     const { context } = getContext();
     context.state.stepIds.push('testStepId');
     context.state.steps['testStepId'] = { type: 'frame-plan', frameId: 'testTestId' };
@@ -85,16 +85,16 @@ describe('count', () => {
     assert(count === 3);
   });
 
-  it('returns count for "describe-plan"', () => {
+  test('returns count for "suite-plan"', () => {
     const { context } = getContext();
     context.state.stepIds.push('testStepId');
-    context.state.steps['testStepId'] = { type: 'describe-plan', describeId: 'testDescribeId' };
-    context.state.describes['testDescribeId'] = { children: [{}, {}, {}] };
+    context.state.steps['testStepId'] = { type: 'suite-plan', suiteId: 'testSuiteId' };
+    context.state.suites['testSuiteId'] = { children: [{}, {}, {}] };
     const count = XTestRoot.count(context, 'testStepId');
     assert(count === 3);
   });
 
-  it('returns count for "exit"', () => {
+  test('returns count for "exit"', () => {
     const { context } = getContext();
     context.state.stepIds.push('testStepId');
     context.state.steps['testStepId'] = { type: 'exit' };
@@ -104,12 +104,12 @@ describe('count', () => {
   });
 });
 
-describe('yaml', () => {
-  it('finds the given "it" step and returns a yaml object', () => {
+suite('yaml', () => {
+  test('finds the given "test" step and returns a yaml object', () => {
     const { context } = getContext();
     context.state.stepIds.push('testStepId');
-    context.state.steps['testStepId'] = { type: 'it', itId: 'testItId' };
-    context.state.its['testItId'] = { ok: false, error: { message: 'test failure', stack: 'test error stack' } };
+    context.state.steps['testStepId'] = { type: 'test', testId: 'testTestId' };
+    context.state.tests['testTestId'] = { ok: false, error: { message: 'test failure', stack: 'test error stack' } };
     const yaml = XTestRoot.yaml(context, 'testStepId');
     assert(yaml.message === 'test failure');
     assert(yaml.severity === 'fail');
@@ -117,8 +117,8 @@ describe('yaml', () => {
   });
 });
 
-describe('end', () => {
-  it('marks state as ended', () => {
+suite('end', () => {
+  test('marks state as ended', () => {
     const { context } = getContext();
     assert(context.state.ended === false);
     XTestRoot.end(context);
@@ -126,20 +126,20 @@ describe('end', () => {
   });
 });
 
-describe('collectFailureStepIds', () => {
-  it('returns failing it step ids in order, excluding TODO and passing', () => {
+suite('collectFailureStepIds', () => {
+  test('returns failing test step ids in order, excluding TODO and passing', () => {
     const { context } = getContext();
     context.state.stepIds.push('s1', 's2', 's3', 's4');
     context.state.steps = {
-      s1: { type: 'it', itId: 'passIt' },
-      s2: { type: 'it', itId: 'failIt' },
-      s3: { type: 'it', itId: 'todoIt' },
+      s1: { type: 'test', testId: 'passTest' },
+      s2: { type: 'test', testId: 'failTest' },
+      s3: { type: 'test', testId: 'todoTest' },
       s4: { type: 'version' },
     };
-    context.state.its = {
-      passIt: { ok: true },
-      failIt: { ok: false },
-      todoIt: { ok: false, directive: 'TODO' },
+    context.state.tests = {
+      passTest: { ok: true },
+      failTest: { ok: false },
+      todoTest: { ok: false, directive: 'TODO' },
     };
     const ids = XTestRoot.collectFailureStepIds(context);
     assert(ids.length === 1);
@@ -148,24 +148,24 @@ describe('collectFailureStepIds', () => {
 
 });
 
-describe('formatFailure', () => {
-  it('formats a failing "it" with arrow-joined breadcrumb and raw stack', () => {
+suite('formatFailure', () => {
+  test('formats a failing "test" with arrow-joined breadcrumb and raw stack', () => {
     const { context } = getContext();
     context.state.stepIds.push('s1');
-    context.state.steps['s1'] = { stepId: 's1', type: 'it', itId: 'i1' };
-    context.state.frames['t1'] = { href: 'http://example.com/test.html', children: [{ type: 'describe', describeId: 'd1' }] };
-    context.state.describes['d1'] = {
+    context.state.steps['s1'] = { stepId: 's1', type: 'test', testId: 'i1' };
+    context.state.frames['t1'] = { href: 'http://example.com/test.html', children: [{ type: 'suite', suiteId: 'd1' }] };
+    context.state.suites['d1'] = {
       text: 'outer',
       parents: [{ type: 'frame', frameId: 't1' }],
-      children: [{ type: 'it', itId: 'i1' }],
+      children: [{ type: 'test', testId: 'i1' }],
     };
-    context.state.its['i1'] = {
-      itId: 'i1',
+    context.state.tests['i1'] = {
+      testId: 'i1',
       text: 'does the thing',
       ok: false,
       directive: null,
       error: { message: 'nope', stack: 'Error: nope\n    at foo' },
-      parents: [{ type: 'frame', frameId: 't1' }, { type: 'describe', describeId: 'd1' }],
+      parents: [{ type: 'frame', frameId: 't1' }, { type: 'suite', suiteId: 'd1' }],
     };
     const block = XTestRoot.formatFailure(context, 's1');
     const lines = block.split('\n');
@@ -176,13 +176,13 @@ describe('formatFailure', () => {
     assert(lines[4] === '    at foo');
   });
 
-  it('falls back to "Error: <message>" when stack is missing', () => {
+  test('falls back to "Error: <message>" when stack is missing', () => {
     const { context } = getContext();
     context.state.stepIds.push('s1');
-    context.state.steps['s1'] = { stepId: 's1', type: 'it', itId: 'i1' };
+    context.state.steps['s1'] = { stepId: 's1', type: 'test', testId: 'i1' };
     context.state.frames['t1'] = { href: 'http://example.com/test.html', children: [] };
-    context.state.its['i1'] = {
-      itId: 'i1',
+    context.state.tests['i1'] = {
+      testId: 'i1',
       text: 'the test',
       ok: false,
       directive: null,
@@ -196,8 +196,8 @@ describe('formatFailure', () => {
 
 });
 
-describe('check', () => {
-  it('does not kick off the exit step once the run has ended (e.g. after a bail)', () => {
+suite('check', () => {
+  test('does not kick off the exit step once the run has ended (e.g. after a bail)', () => {
     const { context } = getContext();
     context.state.stepIds.push('exitStep');
     context.state.steps = { exitStep: { type: 'exit', status: 'waiting' } };

--- a/test/test-scratch.js
+++ b/test/test-scratch.js
@@ -1,40 +1,40 @@
-import { it, describe, assert } from '../x-test.js';
+import { test, suite, assert } from '../x-test.js';
 
-describe.only('this wrapper exercises describe only logic', () => {
-  describe.skip('this wrapper exercises describe skip logic', () => {
-    it('this tests shows inheritance of outer grouping skip directive', () => {
+suite.only('this wrapper exercises suite only logic', () => {
+  suite.skip('this wrapper exercises suite skip logic', () => {
+    test('this tests shows inheritance of outer grouping skip directive', () => {
       assert(false); // this shouldn't get run.
     });
-    it.only('this tests that inner flags override outer ones', () => {
+    test.only('this tests that inner flags override outer ones', () => {
       assert(true);
     });
   });
-  describe.todo('this wrapper exercises describe todo logic', () => {
-    it('this tests shows inheritance of outer grouping todo directive', () => {
+  suite.todo('this wrapper exercises suite todo logic', () => {
+    test('this tests shows inheritance of outer grouping todo directive', () => {
       assert(false, 'this error is expected');
     });
   });
-  it.skip('this simply exercises the skip logic for coverage', () => {
+  test.skip('this simply exercises the skip logic for coverage', () => {
     assert(false); // shouldn't get run
   });
-  describe('this wrapper allows inner tests to declare their own flags', () => {
-    it.todo('this simply exercises the todo logic for coverage', () => {
+  suite('this wrapper allows inner tests to declare their own flags', () => {
+    test.todo('this simply exercises the todo logic for coverage', () => {
       assert(false, 'this error is expected');
     });
-    it.only('this simply exercises the only logic for coverage', () => {
+    test.only('this simply exercises the only logic for coverage', () => {
       assert(true);
     });
   });
 });
 
-describe.only('assert.deepEqual', () => {
-  it('exercises the public assert.deepEqual export', () => {
+suite.only('assert.deepEqual', () => {
+  test('exercises the public assert.deepEqual export', () => {
     assert.deepEqual({ a: [1, 2] }, { a: [1, 2] });
   });
 });
 
-describe.only('interval', () => {
-  it.todo('times out after interval - this is supposed to fail', async () => {
+suite.only('interval', () => {
+  test.todo('times out after interval - this is supposed to fail', async () => {
     await new Promise(resolve => setTimeout(resolve, 1_000));
     assert(true);
   }, 0);

--- a/test/test-tap.js
+++ b/test/test-tap.js
@@ -1,92 +1,92 @@
-import { it, describe, assert } from '../x-test.js';
+import { test, suite, assert } from '../x-test.js';
 import { XTestTap } from '../x-test-tap.js';
 
-describe('version', () => {
-  it('renders "TAP version 14"', () => {
+suite('version', () => {
+  test('renders "TAP version 14"', () => {
     assert(XTestTap.version() === 'TAP version 14');
   });
 });
 
-describe('diagnostic', () => {
-  it('basic', () => {
+suite('diagnostic', () => {
+  test('basic', () => {
     assert(XTestTap.diagnostic('my message') === '# my message');
   });
 
-  it('basic, indented', () => {
+  test('basic, indented', () => {
     assert(XTestTap.diagnostic('my message', 1) === '    # my message');
   });
 
-  it('multiline', () => {
+  test('multiline', () => {
     assert(XTestTap.diagnostic('one\ntwo\nthree') === '# one\n# two\n# three');
   });
 
-  it('multiline, indented', () => {
+  test('multiline, indented', () => {
     assert(XTestTap.diagnostic('one\ntwo\nthree', 1) === '    # one\n    # two\n    # three');
   });
 });
 
-describe('testLine', () => {
-  it('basic, passing', () => {
+suite('testLine', () => {
+  test('basic, passing', () => {
     assert(XTestTap.testLine(true, 1, 'first test') === 'ok 1 - first test');
   });
 
-  it('basic, passing, indented', () => {
+  test('basic, passing, indented', () => {
     assert(XTestTap.testLine(true, 1, 'first test', null, 1) === '    ok 1 - first test');
   });
 
-  it('basic, failing', () => {
+  test('basic, failing', () => {
     assert(XTestTap.testLine(false, 1, 'first test') === 'not ok 1 - first test');
   });
 
-  it('basic, failing, indented', () => {
+  test('basic, failing, indented', () => {
     assert(XTestTap.testLine(false, 1, 'first test', null, 1) === '    not ok 1 - first test');
   });
 
-  it('multiline', () => {
+  test('multiline', () => {
     assert(XTestTap.testLine(true, 1, 'first\ntest') === 'ok 1 - first test');
   });
 
-  it('multiline, indented', () => {
+  test('multiline, indented', () => {
     assert(XTestTap.testLine(true, 1, 'first\ntest', null, 1) === '    ok 1 - first test');
   });
 
-  it('skip', () => {
+  test('skip', () => {
     assert(XTestTap.testLine(true, 1, 'first test', 'SKIP') === 'ok 1 - first test # SKIP');
   });
 
-  it('skip, indented', () => {
+  test('skip, indented', () => {
     assert(XTestTap.testLine(true, 1, 'first test', 'SKIP', 1) === '    ok 1 - first test # SKIP');
   });
 
-  it('todo, passing', () => {
+  test('todo, passing', () => {
     assert(XTestTap.testLine(true, 1, 'first test', 'TODO') === 'ok 1 - first test # TODO');
   });
 
-  it('todo, passing, indented', () => {
+  test('todo, passing, indented', () => {
     assert(XTestTap.testLine(true, 1, 'first test', 'TODO', 1) === '    ok 1 - first test # TODO');
   });
 
-  it('todo, failing', () => {
+  test('todo, failing', () => {
     assert(XTestTap.testLine(false, 1, 'first test', 'TODO') === 'not ok 1 - first test # TODO');
   });
 
-  it('todo, failing, indented', () => {
+  test('todo, failing, indented', () => {
     assert(XTestTap.testLine(false, 1, 'first test', 'TODO', 1) === '    not ok 1 - first test # TODO');
   });
 });
 
-describe('subtest', () => {
-  it('basic', () => {
+suite('subtest', () => {
+  test('basic', () => {
     assert(XTestTap.subtest('my subtest') === '# Subtest: my subtest');
   });
 
-  it('basic, indented', () => {
+  test('basic, indented', () => {
     assert(XTestTap.subtest('my subtest', 1) === '    # Subtest: my subtest');
   });
 });
 
-describe('yaml', () => {
-  it('basic', () => {
+suite('yaml', () => {
+  test('basic', () => {
     const expected = `\
   ---
   message: my message
@@ -99,7 +99,7 @@ describe('yaml', () => {
     assert(XTestTap.yaml('my message', 'error', { stack: 'one\ntwo\nthree' }) === expected);
   });
 
-  it('indented', () => {
+  test('indented', () => {
     const expected = `\
       ---
       message: my message
@@ -113,20 +113,20 @@ describe('yaml', () => {
   });
 });
 
-describe('bailOut', () => {
-  it('basic', () => {
+suite('bailOut', () => {
+  test('basic', () => {
     assert(XTestTap.bailOut('oh no!') === 'Bail out! oh no!');
   });
 
-  it('without message', () => {
+  test('without message', () => {
     assert(XTestTap.bailOut() === 'Bail out!');
     assert(XTestTap.bailOut(null) === 'Bail out!');
     assert(XTestTap.bailOut('') === 'Bail out!');
   });
 });
 
-describe('plan', () => {
-  it('basic', () => {
+suite('plan', () => {
+  test('basic', () => {
     assert(XTestTap.plan(999) === '1..999');
   });
 });

--- a/types/x-test.d.ts
+++ b/types/x-test.d.ts
@@ -14,8 +14,8 @@ export namespace assert {
     function deepEqual<T>(actual: unknown, expected: T, text?: string): asserts actual is T;
 }
 export function load(href: string): void;
-export function describe(text: string, callback: () => void): void;
-export namespace describe {
+export function suite(text: string, callback: () => void): void;
+export namespace suite {
     /**
      * Register a test group that will be skipped during execution.
      * @param {string} text - The description of the test group
@@ -38,8 +38,8 @@ export namespace describe {
      */
     function todo(text: string, callback: () => void): void;
 }
-export function it(text: string, callback: () => void | Promise<void>, interval?: number): void;
-export namespace it {
+export function test(text: string, callback: () => void | Promise<void>, interval?: number): void;
+export namespace test {
     /**
      * Register a test case that will be skipped during execution.
      * @param {string} text - The description of the test case

--- a/x-test-frame.js
+++ b/x-test-frame.js
@@ -33,7 +33,7 @@ export class XTestFrame {
       XTestFrame.bail(context, event.reason);
     });
 
-    // The registration window stays open until “DOMContentLoaded”, which allows
+    // The registration window stays open until "DOMContentLoaded", which allows
     //  folks to import fixtures via JSON Modules and register tests before
     //  registration ends. Note that this does _NOT_ support top-level awaits.
     await context.domContentLoadedPromise;
@@ -59,22 +59,22 @@ export class XTestFrame {
   static async onRun(context, event) {
     if (
       !context.state.bailed &&
-      context.state.callbacks[event.data.data.itId]
+      context.state.callbacks[event.data.data.testId]
     ) {
-      const { itId, directive, interval } = event.data.data;
+      const { testId, directive, interval } = event.data.data;
       try {
         if (directive !== 'SKIP') {
-          const callback = context.state.callbacks[itId];
+          const callback = context.state.callbacks[testId];
           const resolvedInterval = interval ?? 30_000;
           const timeout = await Promise.race([callback(), context.timeout(resolvedInterval)]);
           if (timeout === XTestCommon.TIMEOUT) {
             throw new Error(`timeout after ${resolvedInterval.toLocaleString()}ms`);
           }
         }
-        context.publish('x-test-frame-result', { itId, ok: true, error: null });
+        context.publish('x-test-frame-result', { testId, ok: true, error: null });
       } catch (error) {
         error = XTestFrame.createError(error); // eslint-disable-line no-ex-assign
-        context.publish('x-test-frame-result', { itId, ok: false, error });
+        context.publish('x-test-frame-result', { testId, ok: false, error });
       }
     }
   }
@@ -176,7 +176,7 @@ export class XTestFrame {
       throw new Error('deepEqual does not support symbol-keyed properties.');
     }
 
-    // Exit early if key length doesn’t match.
+    // Exit early if key length doesn't match.
     if (Object.keys(a).length !== Object.keys(b).length) {
       return false;
     }
@@ -211,24 +211,24 @@ export class XTestFrame {
    * @param {any} directive
    * @param {any} only
    */
-  static #describerInner(context, text, callback, directive, only) {
+  static #suiteInner(context, text, callback, directive, only) {
     if (context && !context.state.bailed && !context.state.ready) {
       if (!(callback instanceof Function)) {
         throw new Error(`Unexpected callback value "${callback}".`);
       }
-      const describeId = context.uuid();
+      const suiteId = context.uuid();
       const parents = [...context.state.parents];
       directive = directive ?? null;
       only = only ?? false;
       context.publish(
         'x-test-frame-register',
-        { type: 'describe-start', describeId, parents, text, directive, only }
+        { type: 'suite-start', suiteId, parents, text, directive, only }
       );
       try {
-        context.state.parents.push({ type: 'describe', describeId });
+        context.state.parents.push({ type: 'suite', suiteId });
         callback();
         context.state.parents.pop();
-        context.publish('x-test-frame-register', { type: 'describe-end', describeId });
+        context.publish('x-test-frame-register', { type: 'suite-end', suiteId });
       } catch (error) {
         XTestFrame.bail(context, error);
       }
@@ -240,8 +240,8 @@ export class XTestFrame {
    * @param {any} text
    * @param {any} callback
    */
-  static describe(context, text, callback) {
-    XTestFrame.#describerInner(context, text, callback, null, null);
+  static suite(context, text, callback) {
+    XTestFrame.#suiteInner(context, text, callback, null, null);
   }
 
   /**
@@ -249,8 +249,8 @@ export class XTestFrame {
    * @param {any} text
    * @param {any} callback
    */
-  static describeSkip(context, text, callback) {
-    XTestFrame.#describerInner(context, text, callback, 'SKIP', null);
+  static suiteSkip(context, text, callback) {
+    XTestFrame.#suiteInner(context, text, callback, 'SKIP', null);
   }
 
   /**
@@ -258,8 +258,8 @@ export class XTestFrame {
    * @param {any} text
    * @param {any} callback
    */
-  static describeOnly(context, text, callback) {
-    XTestFrame.#describerInner(context, text, callback, null, true);
+  static suiteOnly(context, text, callback) {
+    XTestFrame.#suiteInner(context, text, callback, null, true);
   }
 
   /**
@@ -267,8 +267,8 @@ export class XTestFrame {
    * @param {any} text
    * @param {any} callback
    */
-  static describeTodo(context, text, callback) {
-    XTestFrame.#describerInner(context, text, callback, 'TODO', null);
+  static suiteTodo(context, text, callback) {
+    XTestFrame.#suiteInner(context, text, callback, 'TODO', null);
   }
 
   /**
@@ -279,20 +279,20 @@ export class XTestFrame {
    * @param {any} directive
    * @param {any} only
    */
-  static #itInner(context, text, callback, interval, directive, only) {
+  static #testInner(context, text, callback, interval, directive, only) {
     if (context && !context.state.bailed && !context.state.ready) {
       if (!(callback instanceof Function)) {
         throw new Error(`Unexpected callback value "${callback}".`);
       }
-      const itId = context.uuid();
+      const testId = context.uuid();
       const parents = [...context.state.parents];
       interval = interval ?? null;
       directive = directive ?? null;
       only = only ?? false;
-      context.state.callbacks[itId] = callback;
+      context.state.callbacks[testId] = callback;
       context.publish(
         'x-test-frame-register',
-        { type: 'it', itId, parents, text, interval, directive, only }
+        { type: 'test', testId, parents, text, interval, directive, only }
       );
     }
   }
@@ -303,8 +303,8 @@ export class XTestFrame {
    * @param {any} callback
    * @param {any} interval
    */
-  static it(context, text, callback, interval) {
-    XTestFrame.#itInner(context, text, callback, interval, null, null);
+  static test(context, text, callback, interval) {
+    XTestFrame.#testInner(context, text, callback, interval, null, null);
   }
 
   /**
@@ -313,8 +313,8 @@ export class XTestFrame {
    * @param {any} callback
    * @param {any} interval
    */
-  static itSkip(context, text, callback, interval) {
-    XTestFrame.#itInner(context, text, callback, interval, 'SKIP', null);
+  static testSkip(context, text, callback, interval) {
+    XTestFrame.#testInner(context, text, callback, interval, 'SKIP', null);
   }
 
   /**
@@ -323,8 +323,8 @@ export class XTestFrame {
    * @param {any} callback
    * @param {any} interval
    */
-  static itOnly(context, text, callback, interval) {
-    XTestFrame.#itInner(context, text, callback, interval, null, true);
+  static testOnly(context, text, callback, interval) {
+    XTestFrame.#testInner(context, text, callback, interval, null, true);
   }
 
   /**
@@ -333,7 +333,7 @@ export class XTestFrame {
    * @param {any} callback
    * @param {any} interval
    */
-  static itTodo(context, text, callback, interval) {
-    XTestFrame.#itInner(context, text, callback, interval, 'TODO', null);
+  static testTodo(context, text, callback, interval) {
+    XTestFrame.#testInner(context, text, callback, interval, 'TODO', null);
   }
 }

--- a/x-test-reporter.css.js
+++ b/x-test-reporter.css.js
@@ -160,29 +160,29 @@ a[output]:any-link {
   cursor: pointer;
 }
 
-[it][ok]:not([directive]) {
+[test][ok]:not([directive]) {
   color: var(--ok);
 }
-[it]:not([ok]):not([directive]),
+[test]:not([ok]):not([directive]),
 [bail] {
   color: var(--not-ok);
 }
-[it][ok][directive="skip"] {
+[test][ok][directive="skip"] {
   color: var(--skip);
 }
-[it]:not([ok])[directive="todo"] {
+[test]:not([ok])[directive="todo"] {
   color: var(--todo);
 }
-[it][ok][directive="todo"] {
+[test][ok][directive="todo"] {
   color: var(--todone);
 }
 
 [plan][indent],
-[plan] + [it][ok]:not([directive]),
-[plan] + [it]:not([ok]):not([directive]),
-[plan] + [it][ok][directive="skip"],
-[plan] + [it]:not([ok])[directive="todo"],
-[plan] + [it][ok][directive="todo"] {
+[plan] + [test][ok]:not([directive]),
+[plan] + [test]:not([ok]):not([directive]),
+[plan] + [test][ok][directive="skip"],
+[plan] + [test]:not([ok])[directive="todo"],
+[plan] + [test][ok][directive="todo"] {
   color: var(--subdued);
 }
 

--- a/x-test-reporter.js
+++ b/x-test-reporter.js
@@ -185,14 +185,14 @@ export class XTestReporter extends HTMLElement {
       } else if (text.match(/^(?: {4})*# /)) {
         result.attributes.diagnostic = '';
       } else if (text.match(/^(?: {4})*ok /)) {
-        Object.assign(result.attributes, { it: '', ok: '' });
+        Object.assign(result.attributes, { test: '', ok: '' });
         if (text.match(/^(?: {4})*[^ #][^#]* # SKIP/)) {
           result.attributes.directive = 'skip';
         } else if (text.match(/^(?: {4})*[^ #][^#]* # TODO/)) {
           result.attributes.directive = 'todo';
         }
       } else if (text.match(/^(?: {4})*not ok /)) {
-        result.attributes.it = '';
+        result.attributes.test = '';
         if (text.match(/^(?: {4})*[^ #][^#]* # TODO/)) {
           result.attributes.directive = 'todo';
         } else {

--- a/x-test-root.js
+++ b/x-test-root.js
@@ -161,11 +161,11 @@ export class XTestRoot {
    * @param {any} context
    * @param {any} data
    */
-  static registerDescribeStart(context, data) {
+  static registerSuiteStart(context, data) {
     if (!context.state.ended) {
-      // New "describe-start" (to mark the start of a subtest). Queue it up.
+      // New “suite-start” (to mark the start of a subtest). Queue it up.
       const stepId = context.uuid();
-      const describeId = data.describeId;
+      const suiteId = data.suiteId;
       const index = context.state.stepIds.findLastIndex((/** @type {any} */ candidateId) => {
         const candidate = context.state.steps[candidateId];
         if (candidate.type === 'frame-plan' && candidate.frameId === data.parents[0].frameId) {
@@ -174,12 +174,12 @@ export class XTestRoot {
         return false;
       });
       context.state.stepIds.splice(index, 0, stepId);
-      context.state.steps[stepId] = { stepId, type: 'describe-start', describeId: data.describeId, status: 'waiting' };
-      context.state.describes[describeId] = { ...data, children: [] };
-      if (data.parents.at(-1)?.type === 'describe') {
-        context.state.describes[data.parents.at(-1).describeId].children.push({ type: 'describe', describeId });
+      context.state.steps[stepId] = { stepId, type: 'suite-start', suiteId: data.suiteId, status: 'waiting' };
+      context.state.suites[suiteId] = { ...data, children: [] };
+      if (data.parents.at(-1)?.type === 'suite') {
+        context.state.suites[data.parents.at(-1).suiteId].children.push({ type: 'suite', suiteId });
       } else {
-        context.state.frames[data.parents.at(-1).frameId].children.push({ type: 'describe', describeId });
+        context.state.frames[data.parents.at(-1).frameId].children.push({ type: 'suite', suiteId });
       }
     }
   }
@@ -188,22 +188,22 @@ export class XTestRoot {
    * @param {any} context
    * @param {any} data
    */
-  static registerDescribeEnd(context, data) {
+  static registerSuiteEnd(context, data) {
     if (!context.state.ended) {
-      // Completed "describe-end" (to mark the end of a subtest). Queue it up.
+      // Completed “suite-end” (to mark the end of a subtest). Queue it up.
       const planStepId = context.uuid();
       const endStepId = context.uuid();
-      const describe = context.state.describes[data.describeId];
+      const suite = context.state.suites[data.suiteId];
       const index = context.state.stepIds.findLastIndex((/** @type {any} */ candidateId) => {
         const candidate = context.state.steps[candidateId];
-        if (candidate.type === 'frame-plan' && candidate.frameId === describe.parents[0].frameId) {
+        if (candidate.type === 'frame-plan' && candidate.frameId === suite.parents[0].frameId) {
           return true;
         }
         return false;
       });
       context.state.stepIds.splice(index, 0, planStepId, endStepId);
-      context.state.steps[planStepId] = { stepId: planStepId, type: 'describe-plan', describeId: data.describeId, status: 'waiting' };
-      context.state.steps[endStepId] = { stepId: endStepId, type: 'describe-end', describeId: data.describeId, status: 'waiting' };
+      context.state.steps[planStepId] = { stepId: planStepId, type: 'suite-plan', suiteId: data.suiteId, status: 'waiting' };
+      context.state.steps[endStepId] = { stepId: endStepId, type: 'suite-end', suiteId: data.suiteId, status: 'waiting' };
     }
   }
 
@@ -211,7 +211,7 @@ export class XTestRoot {
    * @param {any} context
    * @param {any} data
    */
-  static registerIt(context, data) {
+  static registerTest(context, data) {
     if (!context.state.ended) {
       // Apply name pattern filtering if present
       if (context.state.namePattern) {
@@ -221,9 +221,9 @@ export class XTestRoot {
         }
       }
 
-      // New "it" (to be run as part of a test suite). Queue it up.
+      // New “test” (to be run as part of a test suite). Queue it up.
       const stepId = context.uuid();
-      const itId = data.itId;
+      const testId = data.testId;
       const index = context.state.stepIds.findLastIndex((/** @type {any} */ candidateId) => {
         const candidate = context.state.steps[candidateId];
         if (candidate.type === 'frame-plan' && candidate.frameId === data.parents[0].frameId) {
@@ -232,33 +232,33 @@ export class XTestRoot {
         return false;
       });
       context.state.stepIds.splice(index, 0, stepId);
-      context.state.steps[stepId] = { stepId, type: 'it', itId: data.itId, status: 'waiting' };
-      context.state.its[itId] = data;
-      if (data.parents.at(-1)?.type === 'describe') {
-        context.state.describes[data.parents.at(-1).describeId].children.push({ type: 'it', itId });
+      context.state.steps[stepId] = { stepId, type: 'test', testId: data.testId, status: 'waiting' };
+      context.state.tests[testId] = data;
+      if (data.parents.at(-1)?.type === 'suite') {
+        context.state.suites[data.parents.at(-1).suiteId].children.push({ type: 'test', testId });
       } else {
-        context.state.frames[data.parents.at(-1).frameId].children.push({ type: 'it', itId });
+        context.state.frames[data.parents.at(-1).frameId].children.push({ type: 'test', testId });
       }
     }
   }
 
   /**
    * @param {any} context
-   * @param {any} it
+   * @param {any} test
    * @returns {string}
    */
-  static buildFullTestName(context, it) {
+  static buildFullTestName(context, test) {
     const parts = [];
 
-    // Add parent describe names in order
-    const describeParents = it.parents.filter((/** @type {any} */ parent) => parent.type === 'describe');
-    for (const parent of describeParents) {
-      const describe = context.state.describes[parent.describeId];
-      parts.push(describe.text);
+    // Add parent suite names in order
+    const suiteParents = test.parents.filter((/** @type {any} */ parent) => parent.type === 'suite');
+    for (const parent of suiteParents) {
+      const suite = context.state.suites[parent.suiteId];
+      parts.push(suite.text);
     }
 
     // Add the test name itself
-    parts.push(it.text);
+    parts.push(test.text);
 
     return parts.join(' ');
   }
@@ -274,14 +274,14 @@ export class XTestRoot {
         case 'frame':
           XTestRoot.registerFrame(context, data);
           break;
-        case 'describe-start':
-          XTestRoot.registerDescribeStart(context, data);
+        case 'suite-start':
+          XTestRoot.registerSuiteStart(context, data);
           break;
-        case 'describe-end':
-          XTestRoot.registerDescribeEnd(context, data);
+        case 'suite-end':
+          XTestRoot.registerSuiteEnd(context, data);
           break;
-        case 'it':
-          XTestRoot.registerIt(context, data);
+        case 'test':
+          XTestRoot.registerTest(context, data);
           break;
         default:
           throw new Error(`Unexpected registration type "${data.type}".`);
@@ -303,42 +303,42 @@ export class XTestRoot {
         readyFrame.ready = true;
       }
       const only = (
-        Object.values(context.state.its).some((/** @type {any} */ candidate) => {
+        Object.values(context.state.tests).some((/** @type {any} */ candidate) => {
           return candidate.only && candidate.parents[0].frameId === data.frameId;
         }) ||
-        Object.values(context.state.describes).some((/** @type {any} */ candidate) => {
+        Object.values(context.state.suites).some((/** @type {any} */ candidate) => {
           return candidate.only && candidate.parents[0].frameId === data.frameId;
         })
       );
       if (only) {
-        for (const it of Object.values(context.state.its)) {
-          if (it.parents[0].frameId === data.frameId) {
-            if (!it.only) {
-              const describeParents = it.parents
-                .filter((/** @type {any} */ candidate) => candidate.type === 'describe')
-                .map((/** @type {any} */ parent) => context.state.describes[parent.describeId]);
-              const hasOnlyDescribeParent = describeParents.some((/** @type {any} */ candidate) => candidate.only);
-              if (!hasOnlyDescribeParent) {
-                it.directive = 'SKIP';
-              } else if (!it.directive) {
-                const lastDescribeParentWithDirective = describeParents.findLast((/** @type {any} */ candidate) => !!candidate.directive);
-                if (lastDescribeParentWithDirective) {
-                  it.directive = lastDescribeParentWithDirective.directive;
+        for (const test of Object.values(context.state.tests)) {
+          if (test.parents[0].frameId === data.frameId) {
+            if (!test.only) {
+              const suiteParents = test.parents
+                .filter((/** @type {any} */ candidate) => candidate.type === 'suite')
+                .map((/** @type {any} */ parent) => context.state.suites[parent.suiteId]);
+              const hasOnlySuiteParent = suiteParents.some((/** @type {any} */ candidate) => candidate.only);
+              if (!hasOnlySuiteParent) {
+                test.directive = 'SKIP';
+              } else if (!test.directive) {
+                const lastSuiteParentWithDirective = suiteParents.findLast((/** @type {any} */ candidate) => !!candidate.directive);
+                if (lastSuiteParentWithDirective) {
+                  test.directive = lastSuiteParentWithDirective.directive;
                 }
               }
             }
           }
         }
       } else {
-        for (const it of Object.values(context.state.its)) {
-          if (it.parents[0].frameId === data.frameId) {
-            if (!it.directive) {
-              const describeParents = it.parents
-                .filter((/** @type {any} */ candidate) => candidate.type === 'describe')
-                .map((/** @type {any} */ parent) => context.state.describes[parent.describeId]);
-              const lastDescribeParentWithDirective = describeParents.findLast((/** @type {any} */ candidate) => !!candidate.directive);
-              if (lastDescribeParentWithDirective) {
-                it.directive = lastDescribeParentWithDirective.directive;
+        for (const test of Object.values(context.state.tests)) {
+          if (test.parents[0].frameId === data.frameId) {
+            if (!test.directive) {
+              const suiteParents = test.parents
+                .filter((/** @type {any} */ candidate) => candidate.type === 'suite')
+                .map((/** @type {any} */ parent) => context.state.suites[parent.suiteId]);
+              const lastSuiteParentWithDirective = suiteParents.findLast((/** @type {any} */ candidate) => !!candidate.directive);
+              if (lastSuiteParentWithDirective) {
+                test.directive = lastSuiteParentWithDirective.directive;
               }
             }
           }
@@ -367,16 +367,16 @@ export class XTestRoot {
   static onResult(context, event) {
     if (!context.state.ended) {
       const data = event.data.data;
-      const it = context.state.its[data.itId];
+      const test = context.state.tests[data.testId];
       const stepId = context.state.stepIds.find((/** @type {any} */ candidateId) => {
         const candidate = context.state.steps[candidateId];
-        return candidate.type === 'it' && candidate.itId === it.itId;
+        return candidate.type === 'test' && candidate.testId === test.testId;
       });
       const step = context.state.steps[stepId];
       if (step.status !== 'running') {
         throw new Error('step to complete is not running');
       }
-      Object.assign(it, { ok: data.ok, error: data.error });
+      Object.assign(test, { ok: data.ok, error: data.error });
       step.status = 'done';
       const ok = XTestRoot.ok(context, stepId);
       const number = XTestRoot.number(context, stepId);
@@ -408,7 +408,7 @@ export class XTestRoot {
    * @param {any} context
    * @param {any} stepId
    */
-  static kickoffDescribeStart(context, stepId) {
+  static kickoffSuiteStart(context, stepId) {
     const level = XTestRoot.level(context, stepId);
     const text = XTestRoot.text(context, stepId);
     const tap = XTestTap.subtest(text, level);
@@ -420,7 +420,7 @@ export class XTestRoot {
    * @param {any} context
    * @param {any} stepId
    */
-  static kickoffDescribePlan(context, stepId) {
+  static kickoffSuitePlan(context, stepId) {
     const level = XTestRoot.level(context, stepId);
     const count = XTestRoot.count(context, stepId);
     const tap = XTestTap.plan(count, level);
@@ -432,7 +432,7 @@ export class XTestRoot {
    * @param {any} context
    * @param {any} stepId
    */
-  static kickoffDescribeEnd(context, stepId) {
+  static kickoffSuiteEnd(context, stepId) {
     const number = XTestRoot.number(context, stepId);
     const ok = XTestRoot.ok(context, stepId);
     const text = XTestRoot.text(context, stepId);
@@ -523,10 +523,10 @@ export class XTestRoot {
    * @param {any} context
    * @param {any} stepId
    */
-  static kickoffIt(context, stepId) {
+  static kickoffTest(context, stepId) {
     const step = context.state.steps[stepId];
-    const { itId, directive, interval } = context.state.its[step.itId];
-    context.publish('x-test-root-run', { itId, directive, interval });
+    const { testId, directive, interval } = context.state.tests[step.testId];
+    context.publish('x-test-root-run', { testId, directive, interval });
     step.status = 'running';
   }
 
@@ -561,9 +561,9 @@ export class XTestRoot {
     const failureStepIds = [];
     for (const stepId of context.state.stepIds) {
       const step = context.state.steps[stepId];
-      if (step.type === 'it') {
-        const it = context.state.its[step.itId];
-        if (it.ok === false && it.directive !== 'TODO') {
+      if (step.type === 'test') {
+        const test = context.state.tests[step.testId];
+        if (test.ok === false && test.directive !== 'TODO') {
           failureStepIds.push(stepId);
         }
       }
@@ -578,20 +578,20 @@ export class XTestRoot {
    */
   static formatFailure(context, stepId) {
     const step = context.state.steps[stepId];
-    const it = context.state.its[step.itId];
-    const frame = context.state.frames[it.parents[0].frameId];
+    const test = context.state.tests[step.testId];
+    const frame = context.state.frames[test.parents[0].frameId];
     const lines = [frame.href];
-    const describeParents = it.parents.filter((/** @type {any} */ parent) => parent.type === 'describe');
-    for (const parent of describeParents) {
-      lines.push(`> ${context.state.describes[parent.describeId].text.replace(/#/g, '*')}`);
+    const suiteParents = test.parents.filter((/** @type {any} */ parent) => parent.type === 'suite');
+    for (const parent of suiteParents) {
+      lines.push(`> ${context.state.suites[parent.suiteId].text.replace(/#/g, '*')}`);
     }
-    lines.push(`> ${it.text.replace(/#/g, '*')}`);
-    if (it.error.stack) {
-      for (const stackLine of it.error.stack.split('\n')) {
+    lines.push(`> ${test.text.replace(/#/g, '*')}`);
+    if (test.error.stack) {
+      for (const stackLine of test.error.stack.split('\n')) {
         lines.push(stackLine);
       }
     } else {
-      lines.push(`Error: ${it.error.message}`);
+      lines.push(`Error: ${test.error.message}`);
     }
     return lines.join('\n');
   }
@@ -606,7 +606,7 @@ export class XTestRoot {
         return context.state.steps[candidateId].status === 'running';
       });
       if (!runningStepId) {
-        // If nothing's running, find the first step that's waiting and run that.
+        // If nothing’s running, find the first step that’s waiting and run that.
         const stepId = context.state.stepIds.find((/** @type {any} */ candidateId) => {
           return context.state.steps[candidateId].status === 'waiting';
         });
@@ -617,16 +617,16 @@ export class XTestRoot {
               XTestRoot.kickoffVersion(context, stepId);
               XTestRoot.check(context);
               break;
-            case 'describe-start':
-              XTestRoot.kickoffDescribeStart(context, stepId);
+            case 'suite-start':
+              XTestRoot.kickoffSuiteStart(context, stepId);
               XTestRoot.check(context);
               break;
-            case 'describe-plan':
-              XTestRoot.kickoffDescribePlan(context, stepId);
+            case 'suite-plan':
+              XTestRoot.kickoffSuitePlan(context, stepId);
               XTestRoot.check(context);
               break;
-            case 'describe-end':
-              XTestRoot.kickoffDescribeEnd(context, stepId);
+            case 'suite-end':
+              XTestRoot.kickoffSuiteEnd(context, stepId);
               XTestRoot.check(context);
               break;
             case 'frame-start':
@@ -641,8 +641,8 @@ export class XTestRoot {
               XTestRoot.kickoffFrameEnd(context, stepId);
               XTestRoot.check(context);
               break;
-            case 'it':
-              XTestRoot.kickoffIt(context, stepId);
+            case 'test':
+              XTestRoot.kickoffTest(context, stepId);
               XTestRoot.check(context);
               break;
             case 'exit':
@@ -713,7 +713,7 @@ export class XTestRoot {
     if (lastIndex !== index) {
       let tap;
       if (index === -1) {
-        // We're done!
+        // We’re done!
         tap = context.state.stepIds.slice(lastIndex).map((/** @type {any} */ targetId) => context.state.steps[targetId].tap);
       } else {
         tap = context.state.stepIds.slice(lastIndex, index).map((/** @type {any} */ targetId) => context.state.steps[targetId].tap);
@@ -735,12 +735,12 @@ export class XTestRoot {
     const step = context.state.steps[stepId];
 
     switch (step.type) {
-      case 'describe-start':
+      case 'suite-start':
       case 'frame-start':
         context.state.queueing = true;
         XTestRoot.queueOrOutput(context, tap, step.type);
         break;
-      case 'describe-plan':
+      case 'suite-plan':
       case 'frame-plan':
         if (XTestRoot.count(context, stepId) === 0) {
           XTestRoot.handleEmptyPlan(context);
@@ -748,8 +748,8 @@ export class XTestRoot {
           XTestRoot.queueOrOutput(context, tap, step.type);
         }
         break;
-      case 'describe-end':
-        if (!XTestRoot.handleEmptyDescribe(context, step)) {
+      case 'suite-end':
+        if (!XTestRoot.handleEmptySuite(context, step)) {
           XTestRoot.queueOrOutput(context, tap, step.type);
         }
         break;
@@ -764,7 +764,7 @@ export class XTestRoot {
       case 'exit':
         XTestRoot.handleExit(context, tap);
         break;
-      case 'it':
+      case 'test':
         XTestRoot.queueOrOutput(context, tap, step.type);
         break;
       default:
@@ -792,10 +792,10 @@ export class XTestRoot {
    * @param {any} step
    * @returns {boolean}
    */
-  static handleEmptyDescribe(context, step) {
-    const describe = context.state.describes[step.describeId];
-    if (describe.children.length === 0) {
-      XTestRoot.removeFromParent(describe.parents, 'describe', step.describeId, context);
+  static handleEmptySuite(context, step) {
+    const suite = context.state.suites[step.suiteId];
+    if (suite.children.length === 0) {
+      XTestRoot.removeFromParent(suite.parents, 'suite', step.suiteId, context);
       return true;
     }
     return false;
@@ -843,13 +843,13 @@ export class XTestRoot {
    */
   static removeFromParent(parents, childType, childId, context) {
     const parentType = parents.at(-1)?.type;
-    if (parentType === 'describe') {
-      const parentDescribe = context.state.describes[parents.at(-1).describeId];
-      const childIndex = parentDescribe.children.findIndex((/** @type {any} */ child) =>
+    if (parentType === 'suite') {
+      const parentSuite = context.state.suites[parents.at(-1).suiteId];
+      const childIndex = parentSuite.children.findIndex((/** @type {any} */ child) =>
         child.type === childType && child[`${childType}Id`] === childId
       );
       if (childIndex !== -1) {
-        parentDescribe.children.splice(childIndex, 1);
+        parentSuite.children.splice(childIndex, 1);
       }
     } else if (parentType === 'frame') {
       const parentFrame = context.state.frames[parents.at(-1).frameId];
@@ -873,7 +873,7 @@ export class XTestRoot {
       context.state.queue.push(...tap);
 
       // Flush queue and stop queueing for end steps
-      if (stepType === 'it' || stepType === 'describe-end' || stepType === 'frame-end') {
+      if (stepType === 'test' || stepType === 'suite-end' || stepType === 'frame-end') {
         context.state.queueing = false;
         XTestRoot.log(context, ...context.state.queue);
         context.state.queue.length = 0;
@@ -893,10 +893,10 @@ export class XTestRoot {
     switch (child.type) {
       case 'frame':
         return context.state.frames[child.frameId].children.every((/** @type {any} */ candidate) => XTestRoot.childOk(context, candidate, options));
-      case 'describe':
-        return context.state.describes[child.describeId].children.every((/** @type {any} */ candidate) => XTestRoot.childOk(context, candidate, options));
-      case 'it':
-        return context.state.its[child.itId].ok || options?.todoOk && context.state.its[child.itId].directive === 'TODO';
+      case 'suite':
+        return context.state.suites[child.suiteId].children.every((/** @type {any} */ candidate) => XTestRoot.childOk(context, candidate, options));
+      case 'test':
+        return context.state.tests[child.testId].ok || options?.todoOk && context.state.tests[child.testId].directive === 'TODO';
       default:
         throw new Error(`Unexpected type "${child.type}".`);
     }
@@ -912,10 +912,10 @@ export class XTestRoot {
     switch (step.type) {
       case 'frame-end':
         return XTestRoot.childOk(context, { type: 'frame', frameId: step.frameId }, { todoOk: true });
-      case 'describe-end':
-        return XTestRoot.childOk(context, { type: 'describe', describeId: step.describeId }, { todoOk: true });
-      case 'it':
-        return XTestRoot.childOk(context, { type: 'it', itId: step.itId });
+      case 'suite-end':
+        return XTestRoot.childOk(context, { type: 'suite', suiteId: step.suiteId }, { todoOk: true });
+      case 'test':
+        return XTestRoot.childOk(context, { type: 'test', testId: step.testId });
       default:
         throw new Error(`Unexpected type "${step.type}".`);
     }
@@ -929,20 +929,20 @@ export class XTestRoot {
   static number(context, stepId) {
     const step = context.state.steps[stepId];
     switch (step.type) {
-      case 'it': {
-        const it = context.state.its[step.itId];
-        const parentChildren = it.parents.at(-1)?.type === 'describe'
-          ? context.state.describes[it.parents.at(-1).describeId].children
-          : context.state.frames[it.parents.at(-1).frameId].children;
-        const index = parentChildren.findIndex((/** @type {any} */ candidate) => candidate.itId === it.itId);
+      case 'test': {
+        const test = context.state.tests[step.testId];
+        const parentChildren = test.parents.at(-1)?.type === 'suite'
+          ? context.state.suites[test.parents.at(-1).suiteId].children
+          : context.state.frames[test.parents.at(-1).frameId].children;
+        const index = parentChildren.findIndex((/** @type {any} */ candidate) => candidate.testId === test.testId);
         return index + 1;
       }
-      case 'describe-end': {
-        const describe = context.state.describes[step.describeId];
-        const parentChildren = describe.parents.at(-1)?.type === 'describe'
-          ? context.state.describes[describe.parents.at(-1).describeId].children
-          : context.state.frames[describe.parents.at(-1).frameId].children;
-        const index = parentChildren.findIndex((/** @type {any} */ candidate) => candidate.describeId === describe.describeId);
+      case 'suite-end': {
+        const suite = context.state.suites[step.suiteId];
+        const parentChildren = suite.parents.at(-1)?.type === 'suite'
+          ? context.state.suites[suite.parents.at(-1).suiteId].children
+          : context.state.frames[suite.parents.at(-1).frameId].children;
+        const index = parentChildren.findIndex((/** @type {any} */ candidate) => candidate.suiteId === suite.suiteId);
         return index + 1;
       }
       case 'frame-end': {
@@ -962,17 +962,17 @@ export class XTestRoot {
    */
   static text(context, stepId) {
     // The regex-replace prevents usage of the special `#` character which is
-    //  meaningful in TAP. It's overly-conservative now — it could be less
+    //  meaningful in TAP. It’s overly-conservative now — it could be less
     //  restrictive in the future.
     const step = context.state.steps[stepId];
     switch (step.type) {
       case 'frame-end':
         return context.state.frames[step.frameId].href;
-      case 'describe-start':
-      case 'describe-end':
-        return context.state.describes[step.describeId].text.replace(/#/g, '*');
-      case 'it':
-        return context.state.its[step.itId].text.replace(/#/g, '*');
+      case 'suite-start':
+      case 'suite-end':
+        return context.state.suites[step.suiteId].text.replace(/#/g, '*');
+      case 'test':
+        return context.state.tests[step.testId].text.replace(/#/g, '*');
       default:
         throw new Error(`Unexpected type "${step.type}".`);
     }
@@ -1002,11 +1002,11 @@ export class XTestRoot {
   static directive(context, stepId) {
     const step = context.state.steps[stepId];
     switch (step.type) {
-      case 'describe-end':
+      case 'suite-end':
       case 'frame-end':
         return null;
-      case 'it':
-        return context.state.its[step.itId].directive;
+      case 'test':
+        return context.state.tests[step.testId].directive;
       default:
         throw new Error(`Unexpected type "${step.type}".`);
     }
@@ -1025,13 +1025,13 @@ export class XTestRoot {
       case 'frame-start':
       case 'frame-end':
         return 0;
-      case 'describe-plan':
-        return context.state.describes[step.describeId].parents.length + 1;
-      case 'describe-start':
-      case 'describe-end':
-        return context.state.describes[step.describeId].parents.length;
-      case 'it':
-        return context.state.its[step.itId].parents.length;
+      case 'suite-plan':
+        return context.state.suites[step.suiteId].parents.length + 1;
+      case 'suite-start':
+      case 'suite-end':
+        return context.state.suites[step.suiteId].parents.length;
+      case 'test':
+        return context.state.tests[step.testId].parents.length;
       default:
         throw new Error(`Unexpected type "${step.type}".`);
     }
@@ -1047,8 +1047,8 @@ export class XTestRoot {
     switch (step.type) {
       case 'frame-plan':
         return context.state.frames[step.frameId].children.length;
-      case 'describe-plan':
-        return context.state.describes[step.describeId].children.length;
+      case 'suite-plan':
+        return context.state.suites[step.suiteId].children.length;
       case 'exit':
         return context.state.children.length;
       default:
@@ -1064,9 +1064,9 @@ export class XTestRoot {
   static yaml(context, stepId) {
     const step = context.state.steps[stepId];
     switch (step.type) {
-      case 'it': {
-        const it = context.state.its[step.itId];
-        const { ok, directive, error } = it;
+      case 'test': {
+        const test = context.state.tests[step.testId];
+        const { ok, directive, error } = test;
         const yaml = { message: 'ok', severity: 'comment', data: /** @type {Record<string, any>} */ ({}) };
         if (ok) {
           if (directive === 'SKIP') {

--- a/x-test.js
+++ b/x-test.js
@@ -41,7 +41,7 @@ export const load = href => XTestFrame.load(suiteContext, href);
  * @param {() => void} callback - The callback function containing nested tests
  * @returns {void}
  */
-export const describe = (text, callback) => XTestFrame.describe(suiteContext, text, callback);
+export const suite = (text, callback) => XTestFrame.suite(suiteContext, text, callback);
 
 /**
  * Register a test group that will be skipped during execution.
@@ -49,7 +49,7 @@ export const describe = (text, callback) => XTestFrame.describe(suiteContext, te
  * @param {() => void} callback - The callback function containing nested tests
  * @returns {void}
  */
-describe.skip = (text, callback) => XTestFrame.describeSkip(suiteContext, text, callback);
+suite.skip = (text, callback) => XTestFrame.suiteSkip(suiteContext, text, callback);
 
 /**
  * Register a test group that will run exclusively (skips other non-only tests).
@@ -57,7 +57,7 @@ describe.skip = (text, callback) => XTestFrame.describeSkip(suiteContext, text, 
  * @param {() => void} callback - The callback function containing nested tests
  * @returns {void}
  */
-describe.only = (text, callback) => XTestFrame.describeOnly(suiteContext, text, callback);
+suite.only = (text, callback) => XTestFrame.suiteOnly(suiteContext, text, callback);
 
 /**
  * Register a placeholder test group for future implementation.
@@ -65,7 +65,7 @@ describe.only = (text, callback) => XTestFrame.describeOnly(suiteContext, text, 
  * @param {() => void} callback - The callback function containing nested tests
  * @returns {void}
  */
-describe.todo = (text, callback) => XTestFrame.describeTodo(suiteContext, text, callback);
+suite.todo = (text, callback) => XTestFrame.suiteTodo(suiteContext, text, callback);
 
 /**
  * Register an individual test case. Alternatively, mark with flags (.skip, .only, .todo).
@@ -74,7 +74,7 @@ describe.todo = (text, callback) => XTestFrame.describeTodo(suiteContext, text, 
  * @param {number} [interval] - Optional timeout in milliseconds
  * @returns {void}
  */
-export const it = (text, callback, interval) => XTestFrame.it(suiteContext, text, callback, interval);
+export const test = (text, callback, interval) => XTestFrame.test(suiteContext, text, callback, interval);
 
 /**
  * Register a test case that will be skipped during execution.
@@ -83,7 +83,7 @@ export const it = (text, callback, interval) => XTestFrame.it(suiteContext, text
  * @param {number} [interval] - Optional timeout in milliseconds
  * @returns {void}
  */
-it.skip = (text, callback, interval) => XTestFrame.itSkip(suiteContext, text, callback, interval);
+test.skip = (text, callback, interval) => XTestFrame.testSkip(suiteContext, text, callback, interval);
 
 /**
  * Register a test case that will run exclusively (skips other non-only tests).
@@ -92,7 +92,7 @@ it.skip = (text, callback, interval) => XTestFrame.itSkip(suiteContext, text, ca
  * @param {number} [interval] - Optional timeout in milliseconds
  * @returns {void}
  */
-it.only = (text, callback, interval) => XTestFrame.itOnly(suiteContext, text, callback, interval);
+test.only = (text, callback, interval) => XTestFrame.testOnly(suiteContext, text, callback, interval);
 
 /**
  * Register a placeholder test case for future implementation.
@@ -101,7 +101,7 @@ it.only = (text, callback, interval) => XTestFrame.itOnly(suiteContext, text, ca
  * @param {number} [interval] - Optional timeout in milliseconds
  * @returns {void}
  */
-it.todo = (text, callback, interval) => XTestFrame.itTodo(suiteContext, text, callback, interval);
+test.todo = (text, callback, interval) => XTestFrame.testTodo(suiteContext, text, callback, interval);
 
 // https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
 /**
@@ -159,7 +159,7 @@ let suiteContext = null;
 if (!frameElement?.getAttribute('data-x-test-frame-id')) {
   const state = {
     ended: false, children: [], stepIds: [], steps: {},
-    frames: {}, describes: {}, its: {}, reporter: null,
+    frames: {}, suites: {}, tests: {}, reporter: null,
     filtering: false, queue: [], queueing: false,
   };
   const rootContext = {


### PR DESCRIPTION
This matches classic unit testing / TAP language. The current top-level interface rhymes with `node:test` — `suite`, `test`, `assert`.

Closes #99.