### PR TITLE
Improve stack traces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Assertion failures now show only user code in the stack trace. Internal
+  x-test frames are stripped via `Error.captureStackTrace` (Chromium / V8), and
+  callbacks are deferred to a fresh micro task so that BroadcastChannel
+  machinery does not appear below user frames (#106).
+
 ## [2.0.0-rc.8] - 2026-04-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@netflix/eslint-config": "3.0.0",
-        "@netflix/x-test-cli": "1.0.0-rc.5",
+        "@netflix/x-test-cli": "1.0.0-rc.6",
         "eslint": "10.1.0",
         "eslint-plugin-jsdoc": "62.8.0",
         "globals": "17.4.0",
@@ -516,9 +516,9 @@
       }
     },
     "node_modules/@netflix/x-test-cli": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@netflix/x-test-cli/-/x-test-cli-1.0.0-rc.5.tgz",
-      "integrity": "sha512-pOf1sVYQwZBIRqtBh1WKIPI7P/CIVb3Pr6Xe1NFPIBB6PAdE69F1oIzqw1+M7tUwtBIdMzzvj52mQUCS8i5ZQA==",
+      "version": "1.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@netflix/x-test-cli/-/x-test-cli-1.0.0-rc.6.tgz",
+      "integrity": "sha512-O9BDIyIHAzIkJnMBIrXWS/rjCjvtodJtMnB4qYWgSbq1ezwI1nIYY0rS/MkhA3k7PnNu6IrCIe/RBIWHsoSH1w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@netflix/eslint-config": "3.0.0",
-    "@netflix/x-test-cli": "1.0.0-rc.5",
+    "@netflix/x-test-cli": "1.0.0-rc.6",
     "eslint": "10.1.0",
     "eslint-plugin-jsdoc": "62.8.0",
     "globals": "17.4.0",

--- a/test/test-frame.js
+++ b/test/test-frame.js
@@ -57,6 +57,7 @@ const getContext = () => {
   publish.calls = [];
   subscribe.calls = [];
   subscribe.callbacks = [];
+  timeout.calls = [];
   timeout.callbacks = [];
   addErrorListener.calls = [];
   addErrorListener.callbacks = [];
@@ -102,8 +103,9 @@ suite('initialize', () => {
     context.state.callbacks['testTestId'] = () => { called = true; };
     assert(called === false);
     context.publish('x-test-root-run', { testId: 'testTestId' });
-    assert(called === true);
+    assert(called === false);
     await new Promise(resolve => setTimeout(resolve));
+    assert(called === true);
     assert(context.publish.calls.length === 4);
     assert(context.publish.calls[0][0] === 'x-test-frame-initialize'); // From initialization (sync).
     assert(context.publish.calls[1][0] === 'x-test-frame-ready'); // From initialization (async).
@@ -143,8 +145,9 @@ suite('initialize', () => {
     };
     assert(called === false);
     context.publish('x-test-root-run', { testId: 'testTestId' });
-    assert(called === true);
+    assert(called === false);
     await new Promise(resolve => setTimeout(resolve));
+    assert(called === true);
     assert(context.publish.calls.length === 4);
     assert(context.publish.calls[0][0] === 'x-test-frame-initialize'); // From initialization (sync).
     assert(context.publish.calls[1][0] === 'x-test-frame-ready'); // From initialization (async).
@@ -162,8 +165,9 @@ suite('initialize', () => {
     context.state.callbacks['testTestId'] = () => { called = true; };
     assert(called === false);
     context.publish('x-test-root-run', { testId: 'testTestId', directive: 'TODO' });
-    assert(called === true);
+    assert(called === false);
     await new Promise(resolve => setTimeout(resolve));
+    assert(called === true);
     assert(context.publish.calls.length === 4);
     assert(context.publish.calls[0][0] === 'x-test-frame-initialize'); // From initialization (sync).
     assert(context.publish.calls[1][0] === 'x-test-frame-ready'); // From initialization (async).
@@ -184,8 +188,9 @@ suite('initialize', () => {
     };
     assert(called === false);
     context.publish('x-test-root-run', { testId: 'testTestId', directive: 'TODO' });
-    assert(called === true);
+    assert(called === false);
     await new Promise(resolve => setTimeout(resolve));
+    assert(called === true);
     assert(context.publish.calls.length === 4);
     assert(context.publish.calls[0][0] === 'x-test-frame-initialize'); // From initialization (sync).
     assert(context.publish.calls[1][0] === 'x-test-frame-ready'); // From initialization (async).
@@ -474,7 +479,7 @@ suite('assert', () => {
   test('defaults message to "not ok"', () => {
     let message;
     try {
-      XTestFrame.assert(makeContext(), false);
+      XTestFrame.assert(makeContext(), null, false);
     } catch (error) {
       message = error.message;
     }
@@ -485,12 +490,12 @@ suite('assert', () => {
 suite('deepEqual', () => {
   const makeContext = () => ({ state: { bailed: false } });
   const expectOk = (actual, expected) => {
-    XTestFrame.deepEqual(makeContext(), actual, expected);
+    XTestFrame.deepEqual(makeContext(), null, actual, expected);
   };
   const expectNotEqual = (actual, expected) => {
     let message;
     try {
-      XTestFrame.deepEqual(makeContext(), actual, expected, 'boom');
+      XTestFrame.deepEqual(makeContext(), null, actual, expected, 'boom');
     } catch (error) {
       message = error.message;
     }
@@ -499,7 +504,7 @@ suite('deepEqual', () => {
   const expectThrows = (actual, expected, matcher) => {
     let message;
     try {
-      XTestFrame.deepEqual(makeContext(), actual, expected);
+      XTestFrame.deepEqual(makeContext(), null, actual, expected);
     } catch (error) {
       message = error.message;
     }
@@ -592,7 +597,7 @@ suite('deepEqual', () => {
   test('uses custom message when provided', () => {
     let message;
     try {
-      XTestFrame.deepEqual({ state: { bailed: false } }, { a: 1 }, { a: 2 }, 'custom');
+      XTestFrame.deepEqual({ state: { bailed: false } }, null, { a: 1 }, { a: 2 }, 'custom');
     } catch (error) {
       message = error.message;
     }
@@ -602,7 +607,7 @@ suite('deepEqual', () => {
   test('defaults message to "not deep equal"', () => {
     let message;
     try {
-      XTestFrame.deepEqual({ state: { bailed: false } }, 1, 2);
+      XTestFrame.deepEqual({ state: { bailed: false } }, null, 1, 2);
     } catch (error) {
       message = error.message;
     }
@@ -610,7 +615,7 @@ suite('deepEqual', () => {
   });
 
   test('is a no-op when context is bailed', () => {
-    XTestFrame.deepEqual({ state: { bailed: true } }, 1, 2, 'should not throw');
+    XTestFrame.deepEqual({ state: { bailed: true } }, null, 1, 2, 'should not throw');
   });
 });
 

--- a/x-test-frame.js
+++ b/x-test-frame.js
@@ -66,7 +66,8 @@ export class XTestFrame {
         if (directive !== 'SKIP') {
           const callback = context.state.callbacks[testId];
           const resolvedInterval = interval ?? 30_000;
-          const timeout = await Promise.race([callback(), context.timeout(resolvedInterval)]);
+          // Create a new stack to remove some internal noise from stack trace on error.
+          const timeout = await Promise.race([Promise.resolve().then(() => callback()), context.timeout(resolvedInterval)]);
           if (timeout === XTestCommon.TIMEOUT) {
             throw new Error(`timeout after ${resolvedInterval.toLocaleString()}ms`);
           }
@@ -109,13 +110,16 @@ export class XTestFrame {
 
   /**
    * @param {any} context
+   * @param {any} caller
    * @param {any} ok
    * @param {any} text
    */
-  static assert(context, ok, text) {
+  static assert(context, caller, ok, text) {
     if (context && !context.state.bailed) {
       if (!ok) {
-        throw new Error(text ?? 'not ok');
+        const error = new Error(text ?? 'not ok');
+        /** @type {any} */ (Error).captureStackTrace?.(error, caller);
+        throw error;
       }
     }
   }
@@ -127,12 +131,13 @@ export class XTestFrame {
    * later. This is meant to be a _strict_ subset of what is provided by
    * node:assert/strict#deepEqual (https://nodejs.org/api/assert.html).
    * @param {any} context
+   * @param {any} caller
    * @param {any} actual
    * @param {any} expected
    * @param {any} [text]
    */
-  static deepEqual(context, actual, expected, text) {
-    XTestFrame.assert(context, XTestFrame.#deepEqual(actual, expected), text ?? 'not deep equal');
+  static deepEqual(context, caller, actual, expected, text) {
+    XTestFrame.assert(context, caller, XTestFrame.#deepEqual(actual, expected), text ?? 'not deep equal');
   }
 
   /**

--- a/x-test.js
+++ b/x-test.js
@@ -11,7 +11,7 @@ import { XTestFrame } from './x-test-frame.js';
  * @param {string} [text] - The assertion message
  * @returns {asserts ok} Throws if condition is falsy.
  */
-export const assert = (ok, text) => XTestFrame.assert(suiteContext, ok, text);
+export const assert = (ok, text) => XTestFrame.assert(suiteContext, assert, ok, text);
 
 /**
  * Strict deep-equality assertion. Supports primitives, plain objects, and arrays.
@@ -24,7 +24,7 @@ export const assert = (ok, text) => XTestFrame.assert(suiteContext, ok, text);
  * @param {string} [text] - The assertion message
  * @returns {asserts actual is T} Throws if values are not deeply equal.
  */
-assert.deepEqual = (actual, expected, text) => XTestFrame.deepEqual(suiteContext, actual, expected, text);
+assert.deepEqual = (actual, expected, text) => XTestFrame.deepEqual(suiteContext, assert.deepEqual, actual, expected, text);
 
 /**
  * Load a new frame.


### PR DESCRIPTION
Two key changes here:

- Use (non-standard) `Error.captureStackTrace` to remove top frames. †
- Consistently open in new micro task stack for cleaner trace tail. ††

†  There are many standards around this which are catching up to what’s
   been _implemented in modern browsers. There is low risk to try and
   use what exists as we await spec standardization.
†† By running actual test callbacks after an additional micro task, we
   set a clean, consistent stack base.

Closes #106.