### PR TITLE
Use pragmas to get “XFrame” coverage to 100%.

### DIFF
--- a/x-test-frame.js
+++ b/x-test-frame.js
@@ -24,6 +24,7 @@ export class XTestFrame {
     });
 
     // Setup global error / rejection handlers.
+    /* x-test:coverage disable */ // Cannot test top-level error handlers.
     context.addErrorListener((/** @type {any} */ event) => {
       event.preventDefault();
       XTestFrame.bail(context, event.error);
@@ -32,6 +33,7 @@ export class XTestFrame {
       event.preventDefault();
       XTestFrame.bail(context, event.reason);
     });
+    /* x-test:coverage enable */
 
     // The registration window stays open until "DOMContentLoaded", which allows
     //  folks to import fixtures via JSON Modules and register tests before

--- a/x-test.config.js
+++ b/x-test.config.js
@@ -6,7 +6,7 @@ export default {
   coverageGoals: {
     './x-test.js':          { lines: 100 },
     './x-test-tap.js':      { lines: 100 },
-    './x-test-frame.js':    { lines: 97 },
+    './x-test-frame.js':    { lines: 100 },
     './x-test-root.js':     { lines: 77 },
     './x-test-reporter.js': { lines: 71 },
   },


### PR DESCRIPTION
There are a couple places where we strictly _cannot_ test functionality. It is desirable to set _exactly_ 100% as a coverage goal so that we cannot back-slide.

By excluding the code we cannot test, we can finally set our baseline.