### PR TITLE
Matches our assert language to common conventions.

### DIFF
--- a/types/x-test.d.ts
+++ b/types/x-test.d.ts
@@ -1,17 +1,18 @@
-export function assert(ok: unknown, text?: string): asserts ok;
+export function assert(value: unknown, message?: string): asserts value;
 export namespace assert {
     /**
-     * Strict deep-equality assertion. Supports primitives, plain objects, and arrays.
-     * Throws (not an assertion failure) for unsupported types like Map/Set/Date/classes.
+     * Strict deep-equality assertion. Supports primitives, plain objects, and
+     * arrays. Throws (not an assertion failure) for unsupported types like Map,
+     * Set, Date, and other classes.
      * @example
      *   assert.deepEqual({ a: 1 }, { a: 1 });
      * @template T
      * @param {unknown} actual - The actual value
      * @param {T} expected - The expected value
-     * @param {string} [text] - The assertion message
+     * @param {string} [message] - The assertion message
      * @returns {asserts actual is T} Throws if values are not deeply equal.
      */
-    function deepEqual<T>(actual: unknown, expected: T, text?: string): asserts actual is T;
+    function deepEqual<T>(actual: unknown, expected: T, message?: string): asserts actual is T;
 }
 export function load(href: string): void;
 export function suite(text: string, callback: () => void): void;

--- a/x-test-frame.js
+++ b/x-test-frame.js
@@ -113,13 +113,13 @@ export class XTestFrame {
   /**
    * @param {any} context
    * @param {any} caller
-   * @param {any} ok
-   * @param {any} text
+   * @param {any} value
+   * @param {any} message
    */
-  static assert(context, caller, ok, text) {
+  static assert(context, caller, value, message) {
     if (context && !context.state.bailed) {
-      if (!ok) {
-        const error = new Error(text ?? 'not ok');
+      if (!value) {
+        const error = new Error(message ?? 'not ok');
         /** @type {any} */ (Error).captureStackTrace?.(error, caller);
         throw error;
       }
@@ -136,10 +136,10 @@ export class XTestFrame {
    * @param {any} caller
    * @param {any} actual
    * @param {any} expected
-   * @param {any} [text]
+   * @param {any} [message]
    */
-  static deepEqual(context, caller, actual, expected, text) {
-    XTestFrame.assert(context, caller, XTestFrame.#deepEqual(actual, expected), text ?? 'not deep equal');
+  static deepEqual(context, caller, actual, expected, message) {
+    XTestFrame.assert(context, caller, XTestFrame.#deepEqual(actual, expected), message ?? 'not deep equal');
   }
 
   /**

--- a/x-test.js
+++ b/x-test.js
@@ -2,29 +2,29 @@ import { XTestCommon } from './x-test-common.js';
 import { XTestRoot } from './x-test-root.js';
 import { XTestFrame } from './x-test-frame.js';
 
-// TODO: #67: Consider requiring explicit boolean conversion.
 /**
- * Simple assertion which throws exception when not "ok".
+ * Simple assertion which throws exception when value is not truthy.
  * @example
  *   assert('foo' === 'bar', 'foo does not equal bar');
- * @param {unknown} ok - The condition to assert (truthy/falsy)
- * @param {string} [text] - The assertion message
- * @returns {asserts ok} Throws if condition is falsy.
+ * @param {unknown} value - The condition to assert (truthy/falsy)
+ * @param {string} [message] - The assertion message
+ * @returns {asserts value} Throws if condition is falsy.
  */
-export const assert = (ok, text) => XTestFrame.assert(suiteContext, assert, ok, text);
+export const assert = (value, message) => XTestFrame.assert(suiteContext, assert, value, message);
 
 /**
- * Strict deep-equality assertion. Supports primitives, plain objects, and arrays.
- * Throws (not an assertion failure) for unsupported types like Map/Set/Date/classes.
+ * Strict deep-equality assertion. Supports primitives, plain objects, and
+ * arrays. Throws (not an assertion failure) for unsupported types like Map,
+ * Set, Date, and other classes.
  * @example
  *   assert.deepEqual({ a: 1 }, { a: 1 });
  * @template T
  * @param {unknown} actual - The actual value
  * @param {T} expected - The expected value
- * @param {string} [text] - The assertion message
+ * @param {string} [message] - The assertion message
  * @returns {asserts actual is T} Throws if values are not deeply equal.
  */
-assert.deepEqual = (actual, expected, text) => XTestFrame.deepEqual(suiteContext, assert.deepEqual, actual, expected, text);
+assert.deepEqual = (actual, expected, message) => XTestFrame.deepEqual(suiteContext, assert.deepEqual, actual, expected, message);
 
 /**
  * Load a new frame.


### PR DESCRIPTION
Just cleaning up the documentation / language around assert to more-closely match that of `node:assert`.