### PR TITLE
Finalize “test” interface (adds “options”).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- All `assert.*` functions now validate their arguments strictly: wrong argument
-  count, wrong types, or a non-string `message` throw immediately with a
-  descriptive error pointing at the call site (#99).
+- `test` and `test.*` now accept an optional `options` object as the second
+  argument — `test(name, options, fn)` — matching `node:test` call signature.
+  The only supported option is `timeout` (number, in milliseconds). Every valid
+  x-test call is a valid `node:test` call (#99).
+- All public API functions (`assert`, `assert.deepEqual`, `assert.throws`,
+  `assert.rejects`, `load`, `suite`, `suite.*`, `test`, `test.*`) now validate
+  their arguments strictly: wrong argument count, wrong types, or invalid option
+  keys throw immediately with a descriptive error pointing at the call site.
 - `assert.throws(fn, error, message?)` and `assert.rejects(fn, error, message?)`
   for asserting that a function throws or an async function rejects. The `error`
   argument is a `RegExp` tested against `String(thrown)` (consistent with

--- a/test/test-scratch.js
+++ b/test/test-scratch.js
@@ -28,8 +28,8 @@ suite.only('this wrapper exercises suite only logic', () => {
 });
 
 suite.only('interval', () => {
-  test.todo('times out after interval - this is supposed to fail', async () => {
+  test.todo('times out after interval - this is supposed to fail', { timeout: 0 }, async () => {
     await new Promise(resolve => setTimeout(resolve, 1_000));
     assert(true);
-  }, 0);
+  });
 });

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -1,12 +1,12 @@
 import { test, suite, assert } from '../x-test.js';
 
-for (const [label, fn] of [
+for (const [name, fn] of [
   ['suite', suite],
   ['suite.skip', suite.skip],
   ['suite.only', suite.only],
   ['suite.todo', suite.todo],
 ]) {
-  suite(label, () => {
+  suite(name, () => {
     test('accepts valid arguments', () => {
       fn('valid suite', () => {});
     });

--- a/test/test-test.js
+++ b/test/test-test.js
@@ -1,18 +1,19 @@
 import { test, suite, assert } from '../x-test.js';
 
-for (const [label, fn] of [
+for (const [name, fn] of [
   ['test', test],
   ['test.skip', test.skip],
   ['test.only', test.only],
   ['test.todo', test.todo],
 ]) {
-  suite(label, () => {
-    test('accepts valid arguments', () => {
+  suite(name, () => {
+    test('accepts (name, fn)', () => {
       fn('valid test', () => {});
     });
 
-    test('accepts valid arguments with timeout', () => {
-      fn('valid test with timeout', () => {}, 1000);
+    test('accepts (name, options, fn)', () => {
+      fn('valid test with options', { timeout: 1000 }, () => {});
+      fn('valid test with empty options', {}, () => {});
     });
 
     test('throws with too few arguments', () => {
@@ -22,26 +23,30 @@ for (const [label, fn] of [
 
     test('throws if name is not a string', () => {
       assert.throws(() => fn(42, () => {}), /^Error: unexpected name, expected string but got "42"$/);
+      assert.throws(() => fn(42, {}, () => {}), /^Error: unexpected name, expected string but got "42"$/);
     });
 
     test('throws if fn is not a Function', () => {
       assert.throws(() => fn('name', 'not-a-function'), /^Error: unexpected fn, expected Function but got "not-a-function"$/);
+      assert.throws(() => fn('name', {}, 'not-a-function'), /^Error: unexpected fn, expected Function but got "not-a-function"$/);
     });
 
-    test('throws if name is not a string with timeout', () => {
-      assert.throws(() => fn(42, () => {}, 1000), /^Error: unexpected name, expected string but got "42"$/);
+    test('throws if options is not a plain object', () => {
+      assert.throws(() => fn('name', null, () => {}), /^Error: unexpected options, expected object but got "null"$/);
+      assert.throws(() => fn('name', 42, () => {}), /^Error: unexpected options, expected object but got "42"$/);
+      assert.throws(() => fn('name', [], () => {}), /^Error: unexpected options, expected object but got ""$/);
     });
 
-    test('throws if fn is not a Function with timeout', () => {
-      assert.throws(() => fn('name', 'not-a-function', 1000), /^Error: unexpected fn, expected Function but got "not-a-function"$/);
+    test('throws if options has unexpected keys', () => {
+      assert.throws(() => fn('name', { unknown: true }, () => {}), /^Error: unexpected options key "unknown"$/);
     });
 
-    test('throws if timeout is not a number', () => {
-      assert.throws(() => fn('name', () => {}, 'not-a-number'), /^Error: unexpected timeout, expected number but got "not-a-number"$/);
+    test('throws if options.timeout is not a number', () => {
+      assert.throws(() => fn('name', { timeout: 'bad' }, () => {}), /^Error: unexpected options\.timeout, expected number but got "bad"$/);
     });
 
     test('throws on extra arguments', () => {
-      assert.throws(() => fn('name', () => {}, 1000, 'extra'), /^Error: unexpected extra arguments$/);
+      assert.throws(() => fn('name', {}, () => {}, 'extra'), /^Error: unexpected extra arguments$/);
     });
   });
 }

--- a/types/x-test.d.ts
+++ b/types/x-test.d.ts
@@ -83,36 +83,70 @@ export namespace suite {
     function todo(name: string, fn: () => void, ...args: any[]): void;
 }
 /**
- * Register an individual test case. Alternatively, mark with flags (.skip, .only, .todo).
- * @param {string} name - The description of the test case
- * @param {() => void | Promise<void>} fn - The test callback function
- * @param {number} [timeout] - Optional timeout in milliseconds
+ * @overload
+ * @param {string} name
+ * @param {() => void | Promise<void>} fn
  * @returns {void}
  */
-export function test(name: string, fn: () => void | Promise<void>, timeout?: number, ...args: any[]): void;
+export function test(name: string, fn: () => void | Promise<void>): void;
+/**
+ * @overload
+ * @param {string} name
+ * @param {TestOptions} options
+ * @param {() => void | Promise<void>} fn
+ * @returns {void}
+ */
+export function test(name: string, options: TestOptions, fn: () => void | Promise<void>): void;
 export namespace test {
     /**
-     * Register a test case that will be skipped during execution.
-     * @param {string} name - The description of the test case
-     * @param {() => void | Promise<void>} fn - The test callback function
-     * @param {number} [timeout] - Optional timeout in milliseconds
+     * @overload
+     * @param {string} name
+     * @param {() => void | Promise<void>} fn
      * @returns {void}
      */
-    function skip(name: string, fn: () => void | Promise<void>, timeout?: number, ...args: any[]): void;
+    function skip(name: string, fn: () => void | Promise<void>): void;
     /**
-     * Register a test case that will run exclusively (skips other non-only tests).
-     * @param {string} name - The description of the test case
-     * @param {() => void | Promise<void>} fn - The test callback function
-     * @param {number} [timeout] - Optional timeout in milliseconds
+     * @overload
+     * @param {string} name
+     * @param {TestOptions} options
+     * @param {() => void | Promise<void>} fn
      * @returns {void}
      */
-    function only(name: string, fn: () => void | Promise<void>, timeout?: number, ...args: any[]): void;
+    function skip(name: string, options: TestOptions, fn: () => void | Promise<void>): void;
     /**
-     * Register a placeholder test case for future implementation.
-     * @param {string} name - The description of the test case
-     * @param {() => void | Promise<void>} fn - The test callback function
-     * @param {number} [timeout] - Optional timeout in milliseconds
+     * @overload
+     * @param {string} name
+     * @param {() => void | Promise<void>} fn
      * @returns {void}
      */
-    function todo(name: string, fn: () => void | Promise<void>, timeout?: number, ...args: any[]): void;
+    function only(name: string, fn: () => void | Promise<void>): void;
+    /**
+     * @overload
+     * @param {string} name
+     * @param {TestOptions} options
+     * @param {() => void | Promise<void>} fn
+     * @returns {void}
+     */
+    function only(name: string, options: TestOptions, fn: () => void | Promise<void>): void;
+    /**
+     * @overload
+     * @param {string} name
+     * @param {() => void | Promise<void>} fn
+     * @returns {void}
+     */
+    function todo(name: string, fn: () => void | Promise<void>): void;
+    /**
+     * @overload
+     * @param {string} name
+     * @param {TestOptions} options
+     * @param {() => void | Promise<void>} fn
+     * @returns {void}
+     */
+    function todo(name: string, options: TestOptions, fn: () => void | Promise<void>): void;
 }
+export type TestOptions = {
+    /**
+     * - Timeout in milliseconds for this test case.
+     */
+    timeout?: number | undefined;
+};

--- a/x-test.js
+++ b/x-test.js
@@ -262,152 +262,249 @@ suite.todo = function todo(name, fn) {
 };
 
 /**
- * Register an individual test case. Alternatively, mark with flags (.skip, .only, .todo).
- * @param {string} name - The description of the test case
- * @param {() => void | Promise<void>} fn - The test callback function
- * @param {number} [timeout] - Optional timeout in milliseconds
+ * @typedef {object} TestOptions
+ * @property {number} [timeout] - Timeout in milliseconds for this test case.
+ */
+
+/**
+ * @overload
+ * @param {string} name
+ * @param {() => void | Promise<void>} fn
  * @returns {void}
  */
-export function test(name, fn, timeout) {
+/**
+ * @overload
+ * @param {string} name
+ * @param {TestOptions} options
+ * @param {() => void | Promise<void>} fn
+ * @returns {void}
+ */
+/**
+ * Register an individual test case. Alternatively, mark with flags (.skip, .only, .todo).
+ * @param {string} name - The description of the test case
+ * @param {(() => void | Promise<void>) | TestOptions} options - The test callback function, or an options object
+ * @param {(() => void | Promise<void>) | undefined} [fn] - The test callback function, when options are provided
+ * @returns {void}
+ */
+export function test(name, options, fn) {
   switch (arguments.length) {
     case 0:
     case 1:
       throw new Error('expected name and fn arguments, but got too few arguments');
-    case 2:
+    case 2: {
+      const actualFn = options;
       if (typeof name !== 'string') {
         throw new Error(`unexpected name, expected string but got "${name}"`);
+      }
+      if (!(actualFn instanceof Function)) {
+        throw new Error(`unexpected fn, expected Function but got "${actualFn}"`);
+      }
+      XTestFrame.test(suiteContext, name, actualFn);
+      break;
+    }
+    case 3: {
+      if (typeof name !== 'string') {
+        throw new Error(`unexpected name, expected string but got "${name}"`);
+      }
+      if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+        throw new Error(`unexpected options, expected object but got "${options}"`);
+      }
+      const unknownKeys = Object.keys(options).filter(key => key !== 'timeout');
+      if (unknownKeys.length > 0) {
+        throw new Error(`unexpected options key "${unknownKeys[0]}"`);
+      }
+      if ('timeout' in options && typeof options.timeout !== 'number') {
+        throw new Error(`unexpected options.timeout, expected number but got "${options.timeout}"`);
       }
       if (!(fn instanceof Function)) {
         throw new Error(`unexpected fn, expected Function but got "${fn}"`);
       }
-      XTestFrame.test(suiteContext, name, fn);
+      XTestFrame.test(suiteContext, name, fn, options.timeout);
       break;
-    case 3:
-      if (typeof name !== 'string') {
-        throw new Error(`unexpected name, expected string but got "${name}"`);
-      }
-      if (!(fn instanceof Function)) {
-        throw new Error(`unexpected fn, expected Function but got "${fn}"`);
-      }
-      if (typeof timeout !== 'number') {
-        throw new Error(`unexpected timeout, expected number but got "${timeout}"`);
-      }
-      XTestFrame.test(suiteContext, name, fn, timeout);
-      break;
+    }
     default:
       throw new Error('unexpected extra arguments');
   }
 }
 
 /**
- * Register a test case that will be skipped during execution.
- * @param {string} name - The description of the test case
- * @param {() => void | Promise<void>} fn - The test callback function
- * @param {number} [timeout] - Optional timeout in milliseconds
+ * @overload
+ * @param {string} name
+ * @param {() => void | Promise<void>} fn
  * @returns {void}
  */
-test.skip = function skip(name, fn, timeout) {
+/**
+ * @overload
+ * @param {string} name
+ * @param {TestOptions} options
+ * @param {() => void | Promise<void>} fn
+ * @returns {void}
+ */
+/**
+ * Register a test case that will be skipped during execution.
+ * @param {string} name - The description of the test case
+ * @param {(() => void | Promise<void>) | TestOptions} options - The test callback function, or an options object
+ * @param {(() => void | Promise<void>) | undefined} [fn] - The test callback function, when options are provided
+ * @returns {void}
+ */
+test.skip = function skip(name, options, fn) {
   switch (arguments.length) {
     case 0:
     case 1:
       throw new Error('expected name and fn arguments, but got too few arguments');
-    case 2:
+    case 2: {
+      const actualFn = options;
       if (typeof name !== 'string') {
         throw new Error(`unexpected name, expected string but got "${name}"`);
+      }
+      if (!(actualFn instanceof Function)) {
+        throw new Error(`unexpected fn, expected Function but got "${actualFn}"`);
+      }
+      XTestFrame.testSkip(suiteContext, name, actualFn);
+      break;
+    }
+    case 3: {
+      if (typeof name !== 'string') {
+        throw new Error(`unexpected name, expected string but got "${name}"`);
+      }
+      if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+        throw new Error(`unexpected options, expected object but got "${options}"`);
+      }
+      const unknownKeys = Object.keys(options).filter(key => key !== 'timeout');
+      if (unknownKeys.length > 0) {
+        throw new Error(`unexpected options key "${unknownKeys[0]}"`);
+      }
+      if ('timeout' in options && typeof options.timeout !== 'number') {
+        throw new Error(`unexpected options.timeout, expected number but got "${options.timeout}"`);
       }
       if (!(fn instanceof Function)) {
         throw new Error(`unexpected fn, expected Function but got "${fn}"`);
       }
-      XTestFrame.testSkip(suiteContext, name, fn);
+      XTestFrame.testSkip(suiteContext, name, fn, options.timeout);
       break;
-    case 3:
-      if (typeof name !== 'string') {
-        throw new Error(`unexpected name, expected string but got "${name}"`);
-      }
-      if (!(fn instanceof Function)) {
-        throw new Error(`unexpected fn, expected Function but got "${fn}"`);
-      }
-      if (typeof timeout !== 'number') {
-        throw new Error(`unexpected timeout, expected number but got "${timeout}"`);
-      }
-      XTestFrame.testSkip(suiteContext, name, fn, timeout);
-      break;
+    }
     default:
       throw new Error('unexpected extra arguments');
   }
 };
 
+/**
+ * @overload
+ * @param {string} name
+ * @param {() => void | Promise<void>} fn
+ * @returns {void}
+ */
+/**
+ * @overload
+ * @param {string} name
+ * @param {TestOptions} options
+ * @param {() => void | Promise<void>} fn
+ * @returns {void}
+ */
 /**
  * Register a test case that will run exclusively (skips other non-only tests).
  * @param {string} name - The description of the test case
- * @param {() => void | Promise<void>} fn - The test callback function
- * @param {number} [timeout] - Optional timeout in milliseconds
+ * @param {(() => void | Promise<void>) | TestOptions} options - The test callback function, or an options object
+ * @param {(() => void | Promise<void>) | undefined} [fn] - The test callback function, when options are provided
  * @returns {void}
  */
-test.only = function only(name, fn, timeout) {
+test.only = function only(name, options, fn) {
   switch (arguments.length) {
     case 0:
     case 1:
       throw new Error('expected name and fn arguments, but got too few arguments');
-    case 2:
+    case 2: {
+      const actualFn = options;
       if (typeof name !== 'string') {
         throw new Error(`unexpected name, expected string but got "${name}"`);
+      }
+      if (!(actualFn instanceof Function)) {
+        throw new Error(`unexpected fn, expected Function but got "${actualFn}"`);
+      }
+      XTestFrame.testOnly(suiteContext, name, actualFn);
+      break;
+    }
+    case 3: {
+      if (typeof name !== 'string') {
+        throw new Error(`unexpected name, expected string but got "${name}"`);
+      }
+      if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+        throw new Error(`unexpected options, expected object but got "${options}"`);
+      }
+      const unknownKeys = Object.keys(options).filter(key => key !== 'timeout');
+      if (unknownKeys.length > 0) {
+        throw new Error(`unexpected options key "${unknownKeys[0]}"`);
+      }
+      if ('timeout' in options && typeof options.timeout !== 'number') {
+        throw new Error(`unexpected options.timeout, expected number but got "${options.timeout}"`);
       }
       if (!(fn instanceof Function)) {
         throw new Error(`unexpected fn, expected Function but got "${fn}"`);
       }
-      XTestFrame.testOnly(suiteContext, name, fn);
+      XTestFrame.testOnly(suiteContext, name, fn, options.timeout);
       break;
-    case 3:
-      if (typeof name !== 'string') {
-        throw new Error(`unexpected name, expected string but got "${name}"`);
-      }
-      if (!(fn instanceof Function)) {
-        throw new Error(`unexpected fn, expected Function but got "${fn}"`);
-      }
-      if (typeof timeout !== 'number') {
-        throw new Error(`unexpected timeout, expected number but got "${timeout}"`);
-      }
-      XTestFrame.testOnly(suiteContext, name, fn, timeout);
-      break;
+    }
     default:
       throw new Error('unexpected extra arguments');
   }
 };
 
 /**
- * Register a placeholder test case for future implementation.
- * @param {string} name - The description of the test case
- * @param {() => void | Promise<void>} fn - The test callback function
- * @param {number} [timeout] - Optional timeout in milliseconds
+ * @overload
+ * @param {string} name
+ * @param {() => void | Promise<void>} fn
  * @returns {void}
  */
-test.todo = function todo(name, fn, timeout) {
+/**
+ * @overload
+ * @param {string} name
+ * @param {TestOptions} options
+ * @param {() => void | Promise<void>} fn
+ * @returns {void}
+ */
+/**
+ * Register a placeholder test case for future implementation.
+ * @param {string} name - The description of the test case
+ * @param {(() => void | Promise<void>) | TestOptions} options - The test callback function, or an options object
+ * @param {(() => void | Promise<void>) | undefined} [fn] - The test callback function, when options are provided
+ * @returns {void}
+ */
+test.todo = function todo(name, options, fn) {
   switch (arguments.length) {
     case 0:
     case 1:
       throw new Error('expected name and fn arguments, but got too few arguments');
-    case 2:
+    case 2: {
+      const actualFn = options;
       if (typeof name !== 'string') {
         throw new Error(`unexpected name, expected string but got "${name}"`);
+      }
+      if (!(actualFn instanceof Function)) {
+        throw new Error(`unexpected fn, expected Function but got "${actualFn}"`);
+      }
+      XTestFrame.testTodo(suiteContext, name, actualFn);
+      break;
+    }
+    case 3: {
+      if (typeof name !== 'string') {
+        throw new Error(`unexpected name, expected string but got "${name}"`);
+      }
+      if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+        throw new Error(`unexpected options, expected object but got "${options}"`);
+      }
+      const unknownKeys = Object.keys(options).filter(key => key !== 'timeout');
+      if (unknownKeys.length > 0) {
+        throw new Error(`unexpected options key "${unknownKeys[0]}"`);
+      }
+      if ('timeout' in options && typeof options.timeout !== 'number') {
+        throw new Error(`unexpected options.timeout, expected number but got "${options.timeout}"`);
       }
       if (!(fn instanceof Function)) {
         throw new Error(`unexpected fn, expected Function but got "${fn}"`);
       }
-      XTestFrame.testTodo(suiteContext, name, fn);
+      XTestFrame.testTodo(suiteContext, name, fn, options.timeout);
       break;
-    case 3:
-      if (typeof name !== 'string') {
-        throw new Error(`unexpected name, expected string but got "${name}"`);
-      }
-      if (!(fn instanceof Function)) {
-        throw new Error(`unexpected fn, expected Function but got "${fn}"`);
-      }
-      if (typeof timeout !== 'number') {
-        throw new Error(`unexpected timeout, expected number but got "${timeout}"`);
-      }
-      XTestFrame.testTodo(suiteContext, name, fn, timeout);
-      break;
+    }
     default:
       throw new Error('unexpected extra arguments');
   }


### PR DESCRIPTION
We aim to be a _strict subset_ of what `node:test` offers — no real reason to diverge there. As such, rather than take `interval` as an optional, positional argument, we should match Node’s _options_ interface which allows for `{ timeout?: number }` to be defined.