### PR TITLE
Use platform’s “crypto.randomUUID” method.

### DIFF
--- a/x-test.js
+++ b/x-test.js
@@ -413,15 +413,11 @@ test.todo = function todo(name, fn, timeout) {
   }
 };
 
-// https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
 /**
  * @returns {string} A UUID string
  */
 function uuid() {
-  return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, c =>
-    // eslint-disable-next-line no-bitwise
-    (+c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +c / 4).toString(16)
-  );
+  return crypto.randomUUID();
 }
 
 // We need two channels since a messages on a channel are not reflected.


### PR DESCRIPTION
Small update to leverage this tool that’s been available since 2022. Previously, we were using “crypto.getRandomValues” which was baseline as of 2015. Note that they _both_ require a “secure context”, so our posture in regards to that should not be changing at all as a result of this swap.